### PR TITLE
ci(actions): trim recurring workflow load

### DIFF
--- a/.github/workflows/enterprise-testing.yml
+++ b/.github/workflows/enterprise-testing.yml
@@ -5,14 +5,16 @@ on:
     branches: [main, Development]
   pull_request:
     branches: [main]
-  schedule:
-    # Run tests daily at 6 AM UTC
-    - cron: '0 6 * * *'
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '18'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Infrastructure and Unit Testing
@@ -21,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: ${{ fromJSON(github.event_name == 'pull_request' && '["20"]' || '["18","20"]') }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -229,6 +231,7 @@ jobs:
     name: 🐳 Docker Build & Test
     runs-on: ubuntu-latest
     needs: comprehensive-tests
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: 📥 Checkout Repository

--- a/.github/workflows/inspector-integration.yml
+++ b/.github/workflows/inspector-integration.yml
@@ -1,9 +1,6 @@
 name: Enhanced MCP Inspector Integration
 
 on:
-  schedule:
-    # Run comprehensive Inspector validation weekly
-    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       test_type:
@@ -113,7 +110,7 @@ jobs:
   visual-regression:
     name: Inspector Visual Regression Testing
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.test_type == 'comprehensive'
+    if: github.event.inputs.test_type == 'comprehensive'
     env:
       VISUAL_BASELINE_URL: ''
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,9 +5,6 @@ on:
     branches: [main] # Keep automatic performance monitoring on the production branch
   pull_request:
     branches: [main] # Run on PRs targeting main
-  schedule:
-    # Run daily
-    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       environment:
@@ -158,7 +155,7 @@ jobs:
   health-check:
     name: Remote Server Health Check
     runs-on: ubuntu-latest
-    if: github.event.schedule
+    if: github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Check remote server health


### PR DESCRIPTION
## Summary
- remove recurring enterprise, inspector, and performance schedules
- keep those workflows available through manual dispatch
- reduce PR node-matrix breadth and skip Docker on PRs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>