### PR TITLE
fix: restore worker-owned oauth registration

### DIFF
--- a/src/server/worker-oauth-entrypoint-runtime.ts
+++ b/src/server/worker-oauth-entrypoint-runtime.ts
@@ -51,6 +51,13 @@ export function shouldBypassOAuthProvider(pathname: string): boolean {
   );
 }
 
+export function isWorkerManagedRegistrationPath(pathname: string): boolean {
+  return (
+    pathname === HOSTED_MCP_OAUTH_CONTRACT.paths.register ||
+    pathname.startsWith(`${HOSTED_MCP_OAUTH_CONTRACT.paths.register}/`)
+  );
+}
+
 export async function handleWorkerOAuthEntrypoint<TEnv extends OAuthEntrypointEnv>(
   request: Request,
   env: TEnv,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -72,6 +72,7 @@ import {
 import { createWorkerLegacyFetchHandler } from './server/worker-request-runtime.js';
 import {
   handleWorkerOAuthEntrypoint,
+  isWorkerManagedRegistrationPath,
   shouldBypassOAuthProvider,
 } from './server/worker-oauth-entrypoint-runtime.js';
 import { authorizeMcpGatewayRequest } from './server/mcp-gateway-auth.js';
@@ -424,9 +425,7 @@ export default {
     if (shouldBypassOAuthProvider(url.pathname)) {
       return handleLegacyWorkerFetch(request, env, ctx);
     }
-    // Let the OAuthProvider handle base /register (RFC 7591 DCR) natively.
-    // Only intercept /register/{clientId} for client management (RFC 7592).
-    if (url.pathname.startsWith(`${HOSTED_MCP_OAUTH_CONTRACT.paths.register}/`)) {
+    if (isWorkerManagedRegistrationPath(url.pathname)) {
       return handleWorkerDynamicClientRegistration(request, env, {
         getRequestOrigin: workerObservabilityRuntime.getRequestOrigin,
         getRegistrationAllowedOrigins: (runtimeEnv) =>

--- a/test/unit/test-worker-oauth-entrypoint-runtime.ts
+++ b/test/unit/test-worker-oauth-entrypoint-runtime.ts
@@ -3,7 +3,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { handleWorkerOAuthEntrypoint } from '../../src/server/worker-oauth-entrypoint-runtime.js';
+import {
+  handleWorkerOAuthEntrypoint,
+  isWorkerManagedRegistrationPath,
+} from '../../src/server/worker-oauth-entrypoint-runtime.js';
 
 describe('handleWorkerOAuthEntrypoint', () => {
   it('rate limits authorize requests before provider execution', async () => {
@@ -36,5 +39,19 @@ describe('handleWorkerOAuthEntrypoint', () => {
     assert.equal(limiterCalls, 1);
     assert.equal(providerCalls, 0);
     assert.equal(response.status, 429);
+  });
+});
+
+describe('isWorkerManagedRegistrationPath', () => {
+  it('claims the public registration endpoint', () => {
+    assert.equal(isWorkerManagedRegistrationPath('/register'), true);
+  });
+
+  it('claims registration management endpoints', () => {
+    assert.equal(isWorkerManagedRegistrationPath('/register/client-123'), true);
+  });
+
+  it('does not claim unrelated oauth routes', () => {
+    assert.equal(isWorkerManagedRegistrationPath('/authorize'), false);
   });
 });


### PR DESCRIPTION
## Summary
- route both /register and /register/{clientId} through the repo's worker-owned registration handler
- make registration route ownership explicit with a dedicated predicate
- add a regression test so the public DCR endpoint cannot silently fall back to provider behavior again

## Validation
- npx tsx --test test/unit/test-worker-oauth-entrypoint-runtime.ts test/unit/test-worker-oauth-registration.ts
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated OAuth registration path routing logic for improved code maintainability and modularity.

* **Tests**
  * Added test coverage for OAuth registration path detection and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->