### PR TITLE
ci: repair main automation workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN addgroup -g 1001 -S mcp && \
 
 # Install dependencies first (for better caching)
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable && pnpm install --frozen-lockfile
+RUN corepack enable && pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- skip package scripts during the Docker dependency layer install so the image build does not run the repo prepare hook before source files exist
- grant release-please the write permissions it needs to create refs and pull requests on main pushes

## Why
- the Docker build was still failing in enterprise because pnpm install ran the prepare hook before scripts/dev/install-git-hooks.mjs had been copied into the image
- release-please was failing with GitHub 403 Resource not accessible by integration because the workflow token lacked write permissions

## Validation
- docker daemon is unavailable in this environment, so the Dockerfile fix is validated by the CI failure signature it directly addresses
- workflow permission change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to support automated release operations.
  * Optimized Docker build process for improved dependency installation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->