### PR TITLE
ci: switch to current release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: node


### PR DESCRIPTION
## Summary
- replace the deprecated google-github-actions release-please wrapper with the current googleapis action

## Why
The main branch release-please workflow is now failing with a deprecated-action fetch failure after the workflow permission issue was fixed.

## Validation
- workflow change only