### PR TITLE
ci: repair local hardening runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
               ;;
             stress-reliability)
               mkdir -p performance-data
-              TRANSPORT=http MCP_HTTP_PORT=3002 METRICS_ENABLED=true METRICS_PORT=3001 pnpm start > performance-data/local-gate-server.log 2>&1 &
+              MCP_HTTP_PORT=3002 MCP_HTTP_HOST=127.0.0.1 pnpm run start:http > performance-data/local-gate-server.log 2>&1 &
               SERVER_PID=$!
               cleanup() {
                 kill "$SERVER_PID" >/dev/null 2>&1 || true
@@ -345,12 +345,12 @@ jobs:
               trap cleanup EXIT
 
               for _ in $(seq 1 30); do
-                if curl -fsS http://127.0.0.1:3001/health >/dev/null 2>&1; then
+                if curl -fsS http://127.0.0.1:3002/health >/dev/null 2>&1; then
                   break
                 fi
                 sleep 1
               done
-              curl -fsS http://127.0.0.1:3001/health >/dev/null
+              curl -fsS http://127.0.0.1:3002/health >/dev/null
 
               pnpm run ci:load-profile-suite -- --light --base-url http://127.0.0.1:3002 --output performance-data/load-profile-baseline.json
               pnpm run ci:load-profile-suite -- --light --base-url http://127.0.0.1:3002 --output performance-data/load-profile-current.json
@@ -367,7 +367,7 @@ jobs:
               ;;
             release-readiness)
               mkdir -p performance-data test-output
-              TRANSPORT=http MCP_HTTP_PORT=3002 METRICS_ENABLED=true METRICS_PORT=3001 pnpm start > performance-data/local-release-readiness-server.log 2>&1 &
+              MCP_HTTP_PORT=3002 MCP_HTTP_HOST=127.0.0.1 pnpm run start:http > performance-data/local-release-readiness-server.log 2>&1 &
               SERVER_PID=$!
               cleanup() {
                 kill "$SERVER_PID" >/dev/null 2>&1 || true
@@ -375,12 +375,12 @@ jobs:
               trap cleanup EXIT
 
               for _ in $(seq 1 30); do
-                if curl -fsS http://127.0.0.1:3001/health >/dev/null 2>&1; then
+                if curl -fsS http://127.0.0.1:3002/health >/dev/null 2>&1; then
                   break
                 fi
                 sleep 1
               done
-              curl -fsS http://127.0.0.1:3001/health >/dev/null
+              curl -fsS http://127.0.0.1:3002/health >/dev/null
 
               RELEASE_READINESS_GATE_POLICY_MODE=${{ steps.gate_policy.outputs.policy_mode }} \
               RUNTIME_SAFETY_GATE_POLICY_MODE=${{ steps.gate_policy.outputs.policy_mode }} \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: node

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,16 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+  release-please-skipped:
+    if: ${{ secrets.RELEASE_PLEASE_TOKEN == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping release-please because RELEASE_PLEASE_TOKEN is not configured."

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cloudflare:tail": "wrangler tail",
     "cloudflare:register:oauth": "node scripts/cloudflare/register-oauth-client.mjs",
     "start": "node dist/index.js",
+    "start:http": "node dist/http.js",
     "doctor": "node dist/index.js --doctor",
     "setup": "node dist/index.js --setup",
     "mcp": "node dist/index.js",

--- a/scripts/dev/install-git-hooks.mjs
+++ b/scripts/dev/install-git-hooks.mjs
@@ -14,8 +14,25 @@ function log(message) {
   process.stdout.write(`${message}\n`);
 }
 
+function isGitAvailable() {
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
 if (!existsSync(gitDir)) {
   log('Skipping git hook installation because `.git` is not present.');
+  process.exit(0);
+}
+
+if (!isGitAvailable()) {
+  log('Skipping git hook installation because `git` is not available.');
   process.exit(0);
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { bootstrapServices } from './infrastructure/bootstrap.js';
+import { container } from './infrastructure/container.js';
+import type { Logger } from './infrastructure/logger.js';
+import { BestPracticeLegalMCPServer } from './server/mcp-server.js';
+import { startHttpTransport } from './server/http-transport-server.js';
+import type { ServerConfig } from './types.js';
+
+bootstrapServices();
+
+const logger = container.get<Logger>('logger');
+const config = container.get<ServerConfig>('config');
+
+const transportConfig = config.httpTransport ?? {
+  port: 3002,
+  host: '0.0.0.0',
+};
+const transportLogger = logger.child('HttpTransportEntrypoint');
+
+const { close } = await startHttpTransport(
+  async () => new BestPracticeLegalMCPServer().getServer(),
+  transportLogger,
+  transportConfig,
+);
+
+transportLogger.info('Legal MCP HTTP transport ready', {
+  host: transportConfig.host,
+  port: transportConfig.port,
+});
+
+let shuttingDown = false;
+
+const shutdown = async (signal: string) => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
+  transportLogger.info('Stopping Legal MCP HTTP transport', { signal });
+  try {
+    await close();
+    process.exit(0);
+  } catch (error) {
+    transportLogger.error(
+      'Failed to stop Legal MCP HTTP transport',
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    process.exit(1);
+  }
+};
+
+for (const signal of ['SIGTERM', 'SIGINT', 'SIGUSR2']) {
+  process.on(signal, () => {
+    void shutdown(signal);
+  });
+}


### PR DESCRIPTION
## Summary
- start a real local streamable HTTP transport for the hardening gates instead of booting the stdio entrypoint with ignored env vars
- add a compiled `start:http` entrypoint and make git hook installation skip cleanly when `git` is unavailable
- make release-please use `RELEASE_PLEASE_TOKEN` when configured and skip cleanly when the repo policy forbids PR creation from the default Actions token

## Validation
- npm run build
- npm run typecheck
- PATH="$(dirname "$(command -v node)")" "$(command -v node)" scripts/dev/install-git-hooks.mjs
- pnpm run ci:release-readiness-gate -- --light --base-url http://127.0.0.1:3002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP transport with configurable startup and graceful shutdown handling.

* **Chores**
  * Updated CI workflows for server startup configuration.
  * Release automation now requires token configuration to execute.
  * Improved installation process with git availability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->