### PR TITLE
ci: fix release-please token gating

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,16 +11,23 @@ permissions:
 
 jobs:
   release-please:
-    if: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: token-check
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [[ -n "${RELEASE_PLEASE_TOKEN}" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: ${{ steps.token-check.outputs.configured == 'false' }}
+        run: echo "Skipping release-please because RELEASE_PLEASE_TOKEN is not configured."
+
+      - if: ${{ steps.token-check.outputs.configured == 'true' }}
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-
-  release-please-skipped:
-    if: ${{ secrets.RELEASE_PLEASE_TOKEN == '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipping release-please because RELEASE_PLEASE_TOKEN is not configured."


### PR DESCRIPTION
## Summary
- move the `RELEASE_PLEASE_TOKEN` presence check into workflow steps so GitHub can evaluate it
- keep release-please truthful: run the action only when a PR-capable token is configured, otherwise emit a clean skip message

## Validation
- cherry-picked cleanly from 2f47c13 onto current `origin/main`