### PR TITLE
ci: gate enterprise production deploy

### DIFF
--- a/.github/workflows/enterprise-testing.yml
+++ b/.github/workflows/enterprise-testing.yml
@@ -272,25 +272,50 @@ jobs:
     runs-on: ubuntu-latest
     needs: [comprehensive-tests, security-quality, docker-build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      GHCR_DEPLOY_USERNAME: ${{ secrets.GHCR_DEPLOY_USERNAME }}
+      GHCR_DEPLOY_TOKEN: ${{ secrets.GHCR_DEPLOY_TOKEN }}
     # To enable protected environments, create an Environment named "production"
     # in your repository settings and then uncomment the next line.
     # environment: production
 
     steps:
+      - name: 🔎 Check production deploy configuration
+        id: deploy-config
+        run: |
+          if [ -n "${GHCR_DEPLOY_USERNAME}" ] && [ -n "${GHCR_DEPLOY_TOKEN}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping production deployment because GHCR_DEPLOY_USERNAME and GHCR_DEPLOY_TOKEN are not both configured."
+
+      - name: ⏭️ Production deployment not configured
+        if: steps.deploy-config.outputs.enabled != 'true'
+        run: echo "Production deployment skipped."
+
       - name: 📥 Checkout Repository
+        if: steps.deploy-config.outputs.enabled == 'true'
         uses: actions/checkout@v4
 
       - name: 🔐 Log in to Container Registry
+        if: steps.deploy-config.outputs.enabled == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.GHCR_DEPLOY_USERNAME }}
+          password: ${{ env.GHCR_DEPLOY_TOKEN }}
 
       - name: 🔧 Set up Docker Buildx
+        if: steps.deploy-config.outputs.enabled == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: 📦 Extract Metadata
+        if: steps.deploy-config.outputs.enabled == 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -301,6 +326,7 @@ jobs:
             type=raw,value=latest
 
       - name: 🚀 Build and Push Docker Image
+        if: steps.deploy-config.outputs.enabled == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -312,6 +338,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: 🎉 Deployment Success Notification
+        if: steps.deploy-config.outputs.enabled == 'true'
         run: |
           echo "🎉 Successfully deployed to production!"
           echo "🐳 Image: ${{ steps.meta.outputs.tags }}"


### PR DESCRIPTION
## Summary
- stop the enterprise production deployment job from attempting GHCR pushes unless deploy credentials are actually configured
- switch the job to explicit GHCR deploy secrets instead of the default GITHUB_TOKEN path that cannot create the package in this repo
- keep the job green with an explicit skip message when production deployment is not configured

## Testing
- pnpm exec prettier -c .github/workflows/enterprise-testing.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment workflow to conditionally execute based on configured deployment secrets, enhancing deployment flexibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->