### PR TITLE
test: harden node18 server integration

### DIFF
--- a/test/integration/test-server-integration.ts
+++ b/test/integration/test-server-integration.ts
@@ -304,9 +304,13 @@ class HTTPClient {
     data: unknown;
     ok: boolean;
   }> {
-    const response = await fetch(url, {
+    const requestUrl = url.replace('://localhost:', '://127.0.0.1:');
+    const response = await fetch(requestUrl, {
       method: options.method || 'GET',
-      headers: options.headers || {},
+      headers: {
+        Connection: 'close',
+        ...(options.headers || {}),
+      },
       body: options.body ? JSON.stringify(options.body) : undefined,
       ...options,
     });


### PR DESCRIPTION
## Summary
- harden the server integration HTTP client for Node 18 by forcing loopback IPv4 instead of localhost
- disable keep-alive reuse in the test harness so server teardown does not leave stale sockets around
- keep the fix scoped to the test harness that was flaking in the enterprise Node 18 lane

## Testing
- npx -y node@18 --import=tsx test/integration/test-server-integration.ts (3 runs)
- npx -y node@18 --import=tsx --test test/unit/test-enterprise-server.ts
- pnpm exec prettier --write test/integration/test-server-integration.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test HTTP request handling in test infrastructure for improved reliability.

---

**Note:** This release contains only internal test infrastructure updates with no changes visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->