### PR TITLE
chore: promote dev to main via main-based branch

### DIFF
--- a/.github/workflows/main-promotion-policy.yml
+++ b/.github/workflows/main-promotion-policy.yml
@@ -12,11 +12,15 @@ jobs:
     name: Require dev promotion
     runs-on: ubuntu-latest
     steps:
-      - name: Enforce dev as the only promotion source
+      - name: Enforce approved promotion sources
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "$HEAD_REF" != "dev" ]; then
-            echo "::error::Pull requests into main must come from dev. Promote validated dev into main instead of merging feature branches directly."
-            exit 1
-          fi
+          case "$HEAD_REF" in
+            dev|promote-dev-to-main-*)
+              ;;
+            *)
+              echo "::error::Pull requests into main must come from dev or an approved promote-dev-to-main-* branch. Promote validated dev into main instead of merging feature branches directly."
+              exit 1
+              ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Prebuilt configs are provided in [`configs/`](./configs):
 - `hosted-remote-claude.json`
 - `hosted-oauth-chatgpt.json`
 - `hosted-oauth-codex.json`
+- `codex.toml`
 - `claude-desktop.json`
 - `claude-desktop-remote.json`
 - `cursor.json`
@@ -168,12 +169,15 @@ Explicit contract examples:
   hosted remote use with Claude-style clients
 - [`configs/hosted-oauth-chatgpt.json`](./configs/hosted-oauth-chatgpt.json) for
   hosted remote OAuth with ChatGPT-style clients
+- [`configs/codex.toml`](./configs/codex.toml) for the current terminal Codex
+  CLI (`~/.codex/config.toml`, then run `codex mcp login courtlistener`)
 - [`configs/hosted-oauth-codex.json`](./configs/hosted-oauth-codex.json) for
-  hosted remote OAuth with Codex-style clients
+  older JSON-based Codex-style clients
 
 Legacy filenames are still shipped for compatibility:
 
-- [`configs/codex.json`](./configs/codex.json) for direct HTTP transport
+- [`configs/codex.json`](./configs/codex.json) for the legacy direct HTTP JSON
+  example
 - [`configs/openai-chatgpt.json`](./configs/openai-chatgpt.json) for hosted
   OAuth
 - [`configs/claude-desktop-remote.json`](./configs/claude-desktop-remote.json)

--- a/configs/codex.toml
+++ b/configs/codex.toml
@@ -1,0 +1,5 @@
+# Terminal Codex CLI MCP config for the hosted CourtListener endpoint.
+# After adding this server, run: codex mcp login courtlistener
+
+[mcp_servers.courtlistener]
+url = "https://courtlistenermcp.blakeoxford.com/mcp"

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -5,11 +5,22 @@
  * Detects MCP clients, prompts for configuration, and writes config files.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { createInterface } from 'node:readline';
 import { homedir, platform } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { redactSecretsInText } from '../infrastructure/secret-redaction.js';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -19,6 +30,7 @@ interface McpClient {
   configFile: string; // template filename in configs/
   configPath: string | null; // target path on disk (null = print to stdout)
   merge: boolean; // whether to merge into an existing config
+  format: 'json' | 'managed-toml';
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -68,6 +80,14 @@ function vscodeSettingsPath(): string {
   return join(home, 'Library', 'Application Support', 'Code', 'User', 'settings.json');
 }
 
+function codexConfigPath(): string {
+  return join(home, '.codex', 'config.toml');
+}
+
+const CODEX_MANAGED_BLOCK_START = '# >>> courtlistener-mcp codex >>>';
+const CODEX_MANAGED_BLOCK_END = '# <<< courtlistener-mcp codex <<<';
+const CODEX_COURTLISTENER_SECTION_HEADER = '[mcp_servers.courtlistener]';
+
 // ── Client definitions ─────────────────────────────────────────────
 
 const CLIENTS: McpClient[] = [
@@ -77,6 +97,7 @@ const CLIENTS: McpClient[] = [
     configFile: 'claude-desktop.json',
     configPath: claudeDesktopConfigPath(),
     merge: true,
+    format: 'json',
   },
   {
     id: 'claude-code',
@@ -84,6 +105,7 @@ const CLIENTS: McpClient[] = [
     configFile: 'claude-desktop.json',
     configPath: claudeCodeConfigPath(),
     merge: true,
+    format: 'json',
   },
   {
     id: 'cursor',
@@ -91,6 +113,7 @@ const CLIENTS: McpClient[] = [
     configFile: 'cursor.json',
     configPath: cursorConfigPath(),
     merge: true,
+    format: 'json',
   },
   {
     id: 'continue',
@@ -98,6 +121,7 @@ const CLIENTS: McpClient[] = [
     configFile: 'continue-dev.json',
     configPath: continueConfigPath(),
     merge: false,
+    format: 'json',
   },
   {
     id: 'vscode-copilot',
@@ -105,6 +129,15 @@ const CLIENTS: McpClient[] = [
     configFile: 'vscode-copilot.json',
     configPath: vscodeSettingsPath(),
     merge: true,
+    format: 'json',
+  },
+  {
+    id: 'codex-cli',
+    name: 'Codex CLI',
+    configFile: 'codex.toml',
+    configPath: codexConfigPath(),
+    merge: false,
+    format: 'managed-toml',
   },
   {
     id: 'zed',
@@ -112,6 +145,7 @@ const CLIENTS: McpClient[] = [
     configFile: 'zed.json',
     configPath: zedSettingsPath(),
     merge: true,
+    format: 'json',
   },
   {
     id: 'other',
@@ -119,6 +153,7 @@ const CLIENTS: McpClient[] = [
     configFile: 'claude-desktop.json',
     configPath: null,
     merge: false,
+    format: 'json',
   },
 ];
 
@@ -136,6 +171,7 @@ function detectClients(): DetectedClient[] {
     cursor: [join(home, '.cursor')],
     continue: [join(home, '.continue')],
     'vscode-copilot': [vscodeSettingsPath(), join(home, '.vscode')],
+    'codex-cli': [codexConfigPath(), join(home, '.codex')],
     zed: [join(home, '.config', 'zed')],
   };
 
@@ -183,14 +219,18 @@ function findConfigsDir(): string {
   );
 }
 
-function loadTemplate(configFile: string, apiKey: string): string {
+function loadTemplate(client: McpClient, apiKey: string): string {
   const configsDir = findConfigsDir();
-  const templatePath = join(configsDir, configFile);
+  const templatePath = join(configsDir, client.configFile);
   let content = readFileSync(templatePath, 'utf-8');
 
   // Replace placeholder paths with actual project path
   const projectDir = process.cwd();
   content = content.replace(/\/path\/to\/courtlistener-mcp/g, projectDir);
+
+  if (client.format !== 'json') {
+    return content;
+  }
 
   // Replace API key placeholder
   if (apiKey) {
@@ -205,6 +245,62 @@ function loadTemplate(configFile: string, apiKey: string): string {
   }
 
   return content;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getCodexManagedBlock(content: string): string {
+  return `${CODEX_MANAGED_BLOCK_START}\n${content.trim()}\n${CODEX_MANAGED_BLOCK_END}`;
+}
+
+function getSafeConfigPreview(
+  client: McpClient,
+  configContent: string,
+  options: { apiKey?: string } = {},
+): string {
+  const preview =
+    client.format === 'managed-toml' ? getCodexManagedBlock(configContent) : configContent;
+  return redactSecretsInText(preview, {
+    additionalSecrets: options.apiKey ? [options.apiKey] : [],
+  });
+}
+
+function stripManagedCodexCourtlistenerBlocks(content: string): string {
+  const managedPattern = new RegExp(
+    `${escapeRegExp(CODEX_MANAGED_BLOCK_START)}[\\s\\S]*?${escapeRegExp(CODEX_MANAGED_BLOCK_END)}`,
+    'gm',
+  );
+  return content.replace(managedPattern, '');
+}
+
+export function hasManagedCodexCourtlistenerBlock(content: string): boolean {
+  return content.includes(CODEX_MANAGED_BLOCK_START) && content.includes(CODEX_MANAGED_BLOCK_END);
+}
+
+export function hasUnmanagedCodexCourtlistenerBlock(content: string): boolean {
+  const contentOutsideManagedBlocks = stripManagedCodexCourtlistenerBlocks(content);
+  return new RegExp(`^\\s*${escapeRegExp(CODEX_COURTLISTENER_SECTION_HEADER)}\\s*$`, 'm').test(
+    contentOutsideManagedBlocks,
+  );
+}
+
+export function upsertManagedCodexCourtlistenerBlock(
+  existingContent: string,
+  managedBlockContent: string,
+): string {
+  const managedBlock = getCodexManagedBlock(managedBlockContent);
+  if (hasManagedCodexCourtlistenerBlock(existingContent)) {
+    const managedPattern = new RegExp(
+      `${escapeRegExp(CODEX_MANAGED_BLOCK_START)}[\\s\\S]*?${escapeRegExp(CODEX_MANAGED_BLOCK_END)}`,
+      'm',
+    );
+    return existingContent.replace(managedPattern, managedBlock);
+  }
+
+  const trimmed = existingContent.trimEnd();
+  return trimmed.length > 0 ? `${trimmed}\n\n${managedBlock}\n` : `${managedBlock}\n`;
 }
 
 function mergeConfig(
@@ -245,8 +341,39 @@ function mergeConfig(
   return existing;
 }
 
+export function writeTextFileAtomically(filePath: string, content: string, mode?: number): void {
+  const targetPath =
+    existsSync(filePath) && lstatSync(filePath).isSymbolicLink()
+      ? realpathSync(filePath)
+      : filePath;
+  const dir = dirname(targetPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  const effectiveMode =
+    mode ?? (existsSync(targetPath) ? statSync(targetPath).mode & 0o777 : undefined);
+
+  const tempPath = `${targetPath}.tmp-${process.pid}`;
+  writeFileSync(tempPath, content, { encoding: 'utf-8', mode: effectiveMode });
+  renameSync(tempPath, targetPath);
+}
+
 function writeConfig(client: McpClient, configContent: string): string | null {
   if (!client.configPath) return null;
+
+  if (client.format === 'managed-toml') {
+    const existing = existsSync(client.configPath) ? readFileSync(client.configPath, 'utf-8') : '';
+    const finalConfig = upsertManagedCodexCourtlistenerBlock(existing, configContent);
+    if (existsSync(client.configPath)) {
+      const backupPath = `${client.configPath}.bak`;
+      if (!existsSync(backupPath)) {
+        copyFileSync(client.configPath, backupPath);
+      }
+    }
+    writeTextFileAtomically(client.configPath, finalConfig, 0o600);
+    return client.configPath;
+  }
 
   const parsed = JSON.parse(configContent) as Record<string, unknown>;
 
@@ -257,12 +384,11 @@ function writeConfig(client: McpClient, configContent: string): string | null {
     finalConfig = parsed;
   }
 
-  const dir = dirname(client.configPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-
-  writeFileSync(client.configPath, JSON.stringify(finalConfig, null, 2) + '\n', 'utf-8');
+  writeTextFileAtomically(
+    client.configPath,
+    JSON.stringify(finalConfig, null, 2) + '\n',
+    existsSync(client.configPath) ? undefined : 0o600,
+  );
   return client.configPath;
 }
 
@@ -318,26 +444,58 @@ export async function runSetup(): Promise<void> {
     console.log(`\n→ Configuring for ${selectedClient.name}\n`);
 
     // Step 3: API key
-    console.log('CourtListener API key (optional — public endpoints work without one).');
-    console.log('Get one free at: https://www.courtlistener.com/help/api/rest/#permissions\n');
-    const apiKey = await ask(rl, 'API key (press Enter to skip): ');
-
-    if (apiKey) {
-      console.log('  ✅ API key will be saved in config');
+    let apiKey = '';
+    if (selectedClient.id === 'codex-cli') {
+      console.log(
+        'Codex CLI uses hosted OAuth for this setup, so no CourtListener API key is needed.',
+      );
+      console.log('You will authenticate after setup with `codex mcp login courtlistener`.\n');
     } else {
-      console.log('  ⏭️  Skipping API key (you can add it later)');
+      console.log('CourtListener API key (optional — public endpoints work without one).');
+      console.log('Get one free at: https://www.courtlistener.com/help/api/rest/#permissions\n');
+      apiKey = await ask(rl, 'API key (press Enter to skip): ');
+
+      if (apiKey) {
+        console.log('  ✅ API key will be saved in config');
+      } else {
+        console.log('  ⏭️  Skipping API key (you can add it later)');
+      }
+      console.log();
     }
-    console.log();
 
     // Step 4: Generate config
-    const configContent = loadTemplate(selectedClient.configFile, apiKey);
+    const configContent = loadTemplate(selectedClient, apiKey);
 
     if (selectedClient.configPath) {
       // Check if file already exists and has courtlistener configured
       if (existsSync(selectedClient.configPath)) {
         try {
           const existing = readFileSync(selectedClient.configPath, 'utf-8');
-          if (existing.includes('courtlistener')) {
+          if (
+            selectedClient.format === 'managed-toml' &&
+            hasUnmanagedCodexCourtlistenerBlock(existing)
+          ) {
+            console.log(
+              `\n⚠️  ${selectedClient.configPath} already has an unmanaged ${CODEX_COURTLISTENER_SECTION_HEADER} entry.`,
+            );
+            console.log(
+              'Merge this managed block manually so the wizard can update it safely later:\n',
+            );
+            console.log('─'.repeat(60));
+            console.log(
+              getSafeConfigPreview(selectedClient, configContent, {
+                apiKey,
+              }),
+            );
+            console.log('─'.repeat(60));
+            printNextSteps(selectedClient, null);
+            return;
+          }
+          if (
+            (selectedClient.format === 'managed-toml' &&
+              hasManagedCodexCourtlistenerBlock(existing)) ||
+            (selectedClient.format === 'json' && existing.includes('courtlistener'))
+          ) {
             const overwrite = await ask(
               rl,
               `⚠️  ${selectedClient.configPath} already has a courtlistener entry. Overwrite? [y/N]: `,
@@ -346,7 +504,7 @@ export async function runSetup(): Promise<void> {
               console.log(
                 '\n⏭️  Skipping config write. Here is the config you can merge manually:\n',
               );
-              console.log(configContent);
+              console.log(getSafeConfigPreview(selectedClient, configContent, { apiKey }));
               printNextSteps(selectedClient, null);
               return;
             }
@@ -365,7 +523,7 @@ export async function runSetup(): Promise<void> {
       // "Other" client — print to stdout
       console.log('Add this to your MCP client configuration:\n');
       console.log('─'.repeat(60));
-      console.log(configContent);
+      console.log(getSafeConfigPreview(selectedClient, configContent, { apiKey }));
       console.log('─'.repeat(60));
       printNextSteps(selectedClient, null);
     }
@@ -376,6 +534,21 @@ export async function runSetup(): Promise<void> {
 
 function printNextSteps(client: McpClient, writtenPath: string | null): void {
   console.log('\n📋 Next steps:\n');
+
+  if (client.id === 'codex-cli') {
+    if (!writtenPath && client.configPath) {
+      console.log(`  1. Copy the managed block above to: ${client.configPath}`);
+      console.log('  2. Run `codex mcp login courtlistener`');
+      console.log('  3. Restart Codex if it is already open');
+      console.log('  4. Run `/mcp` in Codex to confirm the server is available\n');
+    } else {
+      console.log('  1. Run `codex mcp login courtlistener`');
+      console.log('  2. Restart Codex if it is already open');
+      console.log('  3. Run `/mcp` in Codex to confirm the server is available\n');
+    }
+    console.log('📖 Docs: https://developers.openai.com/codex/mcp\n');
+    return;
+  }
 
   if (!writtenPath && client.configPath) {
     console.log(`  1. Copy the config above to: ${client.configPath}`);

--- a/src/server/worker-auth-handoff-routes.ts
+++ b/src/server/worker-auth-handoff-routes.ts
@@ -26,6 +26,10 @@ import {
 } from './worker-upstream-oidc-config.js';
 import type { OAuthFrontdoorRateLimitDeps } from './worker-oauth-frontdoor-rate-limit.js';
 import { getOAuthFrontdoorRateLimitedResponse } from './worker-oauth-frontdoor-rate-limit.js';
+import {
+  cloneHeadersPreservingSetCookie,
+  type HtmlResponseSecurityOptions,
+} from './worker-response-runtime.js';
 
 const AUTH_STATE_COOKIE_NAME = 'clauth_state';
 const AUTH_APPROVAL_COOKIE_NAME = 'clauth_approve';
@@ -958,7 +962,12 @@ interface AuthFlowPayload {
 interface HandleWorkerAuthHandoffRoutesDeps<TEnv extends WorkerUiSessionRuntimeEnv> {
   jsonError: (message: string, status: number, errorCode: string) => Response;
   generateCspNonce: () => string;
-  htmlResponse: (html: string, nonce: string, extraHeaders?: HeadersInit) => Response;
+  htmlResponse: (
+    html: string,
+    nonce: string,
+    extraHeaders?: HeadersInit,
+    securityOptions?: HtmlResponseSecurityOptions,
+  ) => Response;
   workerUiSessionRuntime: WorkerUiSessionRuntime<TEnv>;
   getOAuthHelpers: (env: TEnv) => OAuthHelpers;
   buildHostedOAuthCompletionDetails: (
@@ -1464,7 +1473,10 @@ function appendHostedAuthHeaders(headers: Headers, signal: HostedAuthResponseSig
 }
 
 function attachHostedAuthHeaders(response: Response, signal: HostedAuthResponseSignal): Response {
-  const headers = appendHostedAuthHeaders(new Headers(response.headers), signal);
+  const headers = appendHostedAuthHeaders(
+    cloneHeadersPreservingSetCookie(response.headers),
+    signal,
+  );
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -1982,6 +1994,8 @@ async function buildApprovalPageResponse<
     }),
     nonce,
     headers,
+    // OAuth loopback and hosted callbacks rely on explicit callback origins in the CSP.
+    redirectUri ? { formActionOrigins: [redirectUri.origin] } : undefined,
   );
 }
 

--- a/src/server/worker-response-runtime.ts
+++ b/src/server/worker-response-runtime.ts
@@ -1,5 +1,15 @@
 import { buildMcpCorsHeaders } from './transport-boundary-headers.js';
 
+export interface HtmlResponseSecurityOptions {
+  formActionOrigins?: string[];
+}
+
+export function cloneHeadersPreservingSetCookie(source: Headers): Headers {
+  const headers = new Headers();
+  appendHeaders(headers, source);
+  return headers;
+}
+
 export function jsonResponse(payload: unknown, status = 200, extraHeaders?: HeadersInit): Response {
   const headers = createSecureResponseHeaders({ 'Cache-Control': 'no-store' }, extraHeaders);
   return Response.json(payload, {
@@ -34,14 +44,22 @@ export function generateCspNonce(): string {
   return btoa(binary);
 }
 
-export function htmlResponse(html: string, nonce: string, extraHeaders?: HeadersInit): Response {
+export function htmlResponse(
+  html: string,
+  nonce: string,
+  extraHeaders?: HeadersInit,
+  securityOptions?: HtmlResponseSecurityOptions,
+): Response {
   const headers = createSecureResponseHeaders(
     {
       'content-type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-store',
     },
     extraHeaders,
-    nonce,
+    {
+      nonce,
+      ...securityOptions,
+    },
   );
   return new Response(html, {
     status: 200,
@@ -90,7 +108,7 @@ export function withCors(
   origin: string | null,
   allowedOrigins: string[],
 ): Response {
-  const headers = new Headers(response.headers);
+  const headers = cloneHeadersPreservingSetCookie(response.headers);
   const corsHeaders = buildCorsHeaders(origin, allowedOrigins);
   for (const [key, value] of corsHeaders.entries()) {
     headers.set(key, value);
@@ -105,33 +123,43 @@ export function withCors(
 
 function appendHeaders(headers: Headers, extraHeaders?: HeadersInit): void {
   if (!extraHeaders) return;
-  const source = new Headers(extraHeaders);
+  const source = extraHeaders instanceof Headers ? extraHeaders : new Headers(extraHeaders);
+  const setCookieValues = getSetCookieValues(extraHeaders, source);
   for (const [key, value] of source.entries()) {
+    if (key.toLowerCase() === 'set-cookie') continue;
     headers.append(key, value);
+  }
+  for (const value of setCookieValues) {
+    headers.append('Set-Cookie', value);
   }
 }
 
 function createSecureResponseHeaders(
   baseHeaders: HeadersInit,
   extraHeaders?: HeadersInit,
-  nonce?: string,
+  securityOptions?: { nonce?: string; formActionOrigins?: string[] },
 ): Headers {
   const headers = new Headers(baseHeaders);
   appendHeaders(headers, extraHeaders);
-  applySecurityHeaders(headers, nonce);
+  applySecurityHeaders(headers, securityOptions);
   return headers;
 }
 
-function applySecurityHeaders(headers: Headers, nonce?: string): void {
+function applySecurityHeaders(
+  headers: Headers,
+  securityOptions?: { nonce?: string; formActionOrigins?: string[] },
+): void {
   headers.set('X-Content-Type-Options', 'nosniff');
   headers.set('X-Frame-Options', 'DENY');
   headers.set('Referrer-Policy', 'no-referrer');
   headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
   headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+  const nonce = securityOptions?.nonce;
   const scriptDirective = nonce
     ? `script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com`
     : "script-src 'none'";
   const styleDirective = nonce ? `style-src 'self' 'nonce-${nonce}'` : "style-src 'none'";
+  const formActionOrigins = normalizeFormActionOrigins(securityOptions?.formActionOrigins ?? []);
   headers.set(
     'Content-Security-Policy',
     [
@@ -144,7 +172,45 @@ function applySecurityHeaders(headers: Headers, nonce?: string): void {
       styleDirective,
       "connect-src 'self'",
       'frame-src https://challenges.cloudflare.com',
-      "form-action 'self'",
+      `form-action 'self'${formActionOrigins.length > 0 ? ` ${formActionOrigins.join(' ')}` : ''}`,
     ].join('; '),
   );
+}
+
+function normalizeFormActionOrigins(origins: string[]): string[] {
+  const uniqueOrigins = new Set<string>();
+  for (const candidate of origins) {
+    const normalized = candidate.trim();
+    if (!normalized) continue;
+    try {
+      const origin = new URL(normalized).origin;
+      if (origin === 'null' || origin === 'file://') continue;
+      uniqueOrigins.add(origin);
+    } catch {
+      continue;
+    }
+  }
+  return [...uniqueOrigins];
+}
+
+function getSetCookieValues(source: HeadersInit, headers: Headers): string[] {
+  if (Array.isArray(source)) {
+    return source.filter(([key]) => key.toLowerCase() === 'set-cookie').map(([, value]) => value);
+  }
+
+  if (source instanceof Headers && typeof source.getSetCookie === 'function') {
+    return source.getSetCookie();
+  }
+
+  if (typeof headers.getSetCookie === 'function') {
+    return headers.getSetCookie();
+  }
+
+  if (headers.has('set-cookie')) {
+    throw new Error(
+      'Preserving multiple Set-Cookie headers from a Headers object requires a runtime with Headers.getSetCookie().',
+    );
+  }
+
+  return [];
 }

--- a/src/web-spa/e2e/real-auth-flow.spec.ts
+++ b/src/web-spa/e2e/real-auth-flow.spec.ts
@@ -1,16 +1,69 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { expect, test, type Page } from 'playwright/test';
 import { startLocalAuthFlowServer } from './support/local-auth-flow-server';
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
 test.describe('SPA real auth flow', () => {
   let server: Awaited<ReturnType<typeof startLocalAuthFlowServer>>;
+  let externalCallbackServer: Awaited<ReturnType<typeof startExternalCallbackServer>>;
 
   test.beforeAll(async () => {
     server = await startLocalAuthFlowServer();
+    externalCallbackServer = await startExternalCallbackServer();
   });
 
   test.afterAll(async () => {
     await server.close();
+    await externalCallbackServer.close();
   });
+
+  async function startExternalCallbackServer(): Promise<{
+    baseUrl: string;
+    close: () => Promise<void>;
+  }> {
+    const callbackServer = http.createServer((request, response) => {
+      const requestUrl = new URL(request.url || '/', 'http://127.0.0.1');
+      const code = escapeHtml(requestUrl.searchParams.get('code') || '');
+      const state = escapeHtml(requestUrl.searchParams.get('state') || '');
+      response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      response.end(
+        `<html><body><h1>External authorization completed</h1><p>code=${code}</p><p>state=${state}</p></body></html>`,
+      );
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      callbackServer.once('error', reject);
+      callbackServer.listen(0, '127.0.0.1', () => {
+        callbackServer.off('error', reject);
+        resolve();
+      });
+    });
+
+    const address = callbackServer.address() as AddressInfo;
+    return {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      close: async () => {
+        await new Promise<void>((resolve, reject) => {
+          callbackServer.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        });
+      },
+    };
+  }
 
   async function bootstrapSession(page: Page): Promise<void> {
     await page.goto(`${server.baseUrl}/app/control-center`);
@@ -107,5 +160,38 @@ test.describe('SPA real auth flow', () => {
     expect(callbackUrl.pathname).toBe('/client/callback');
     expect(callbackUrl.searchParams.get('code')).toBe('local-auth-code');
     expect(callbackUrl.searchParams.get('state')).toBe('state-1');
+  });
+
+  test('allows approval to complete against a loopback callback origin', async ({ page }) => {
+    await bootstrapSession(page);
+
+    const authorizeUrl = new URL('/oauth/authorize', server.baseUrl);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', 'client-loopback');
+    authorizeUrl.searchParams.set('redirect_uri', `${externalCallbackServer.baseUrl}/callback`);
+    authorizeUrl.searchParams.set('state', 'state-loopback');
+    authorizeUrl.searchParams.set('scope', 'legal:read legal:search');
+    authorizeUrl.searchParams.set('code_challenge', 'challenge');
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+
+    await page.goto(authorizeUrl.toString());
+
+    await expect(page.getByRole('heading', { name: 'Approve OAuth access' })).toBeVisible();
+    await page.getByRole('button', { name: 'Approve and continue' }).click();
+
+    await page.waitForURL(
+      new RegExp(
+        `${externalCallbackServer.baseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/callback\\?`,
+      ),
+    );
+    await expect(
+      page.getByRole('heading', { name: 'External authorization completed' }),
+    ).toBeVisible();
+
+    const callbackUrl = new URL(page.url());
+    expect(callbackUrl.origin).toBe(externalCallbackServer.baseUrl);
+    expect(callbackUrl.pathname).toBe('/callback');
+    expect(callbackUrl.searchParams.get('code')).toBe('local-auth-code');
+    expect(callbackUrl.searchParams.get('state')).toBe('state-loopback');
   });
 });

--- a/src/web-spa/e2e/real-auth-flow.spec.ts
+++ b/src/web-spa/e2e/real-auth-flow.spec.ts
@@ -3,15 +3,6 @@ import type { AddressInfo } from 'node:net';
 import { expect, test, type Page } from 'playwright/test';
 import { startLocalAuthFlowServer } from './support/local-auth-flow-server';
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
 test.describe('SPA real auth flow', () => {
   let server: Awaited<ReturnType<typeof startLocalAuthFlowServer>>;
   let externalCallbackServer: Awaited<ReturnType<typeof startExternalCallbackServer>>;
@@ -30,14 +21,9 @@ test.describe('SPA real auth flow', () => {
     baseUrl: string;
     close: () => Promise<void>;
   }> {
-    const callbackServer = http.createServer((request, response) => {
-      const requestUrl = new URL(request.url || '/', 'http://127.0.0.1');
-      const code = escapeHtml(requestUrl.searchParams.get('code') || '');
-      const state = escapeHtml(requestUrl.searchParams.get('state') || '');
+    const callbackServer = http.createServer((_request, response) => {
       response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
-      response.end(
-        `<html><body><h1>External authorization completed</h1><p>code=${code}</p><p>state=${state}</p></body></html>`,
-      );
+      response.end('<html><body><h1>External authorization completed</h1></body></html>');
     });
 
     await new Promise<void>((resolve, reject) => {

--- a/test/unit/test-cli-setup.ts
+++ b/test/unit/test-cli-setup.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  hasManagedCodexCourtlistenerBlock,
+  hasUnmanagedCodexCourtlistenerBlock,
+  upsertManagedCodexCourtlistenerBlock,
+  writeTextFileAtomically,
+} from '../../src/cli/setup.js';
+
+describe('cli setup codex helpers', () => {
+  const managedTomlBlock = `
+[mcp_servers.courtlistener]
+url = "https://courtlistenermcp.blakeoxford.com/mcp"
+`.trim();
+
+  it('appends a managed Codex MCP block without changing unrelated config', () => {
+    const existing = `
+model = "gpt-5.5"
+
+[features]
+multi_agent = true
+`.trim();
+
+    const updated = upsertManagedCodexCourtlistenerBlock(existing, managedTomlBlock);
+
+    assert.match(updated, /^model = "gpt-5\.5"/);
+    assert.match(updated, /\[features\]\nmulti_agent = true/);
+    assert.ok(hasManagedCodexCourtlistenerBlock(updated));
+    assert.match(
+      updated,
+      /\[mcp_servers\.courtlistener\]\nurl = "https:\/\/courtlistenermcp\.blakeoxford\.com\/mcp"/,
+    );
+  });
+
+  it('replaces only the managed Codex MCP block on rerun', () => {
+    const existing = `
+model = "gpt-5.5"
+
+# >>> courtlistener-mcp codex >>>
+[mcp_servers.courtlistener]
+url = "https://old.example.com/mcp"
+# <<< courtlistener-mcp codex <<<
+
+[features]
+multi_agent = true
+`.trim();
+
+    const updated = upsertManagedCodexCourtlistenerBlock(existing, managedTomlBlock);
+
+    assert.doesNotMatch(updated, /url = "https:\/\/old\.example\.com\/mcp"/);
+    assert.equal(updated.match(/# >>> courtlistener-mcp codex >>>/g)?.length, 1);
+    assert.equal(updated.match(/# <<< courtlistener-mcp codex <<</g)?.length, 1);
+    assert.match(updated, /\[features\]\nmulti_agent = true/);
+  });
+
+  it('detects unmanaged existing courtlistener Codex sections', () => {
+    const unmanaged = `
+[mcp_servers.courtlistener]
+url = "https://custom.example.com/mcp"
+`.trim();
+
+    assert.equal(hasUnmanagedCodexCourtlistenerBlock(unmanaged), true);
+    assert.equal(hasManagedCodexCourtlistenerBlock(unmanaged), false);
+  });
+
+  it('detects unmanaged Codex sections outside the managed block', () => {
+    const mixed = `
+# >>> courtlistener-mcp codex >>>
+[mcp_servers.courtlistener]
+url = "https://courtlistenermcp.blakeoxford.com/mcp"
+# <<< courtlistener-mcp codex <<<
+
+[mcp_servers.courtlistener]
+url = "https://custom.example.com/mcp"
+`.trim();
+
+    assert.equal(hasManagedCodexCourtlistenerBlock(mixed), true);
+    assert.equal(hasUnmanagedCodexCourtlistenerBlock(mixed), true);
+  });
+
+  it('preserves symlink targets and existing file mode for atomic writes', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'courtlistener-cli-setup-'));
+    try {
+      const targetDir = join(tempDir, 'real');
+      mkdirSync(targetDir, { recursive: true });
+      const targetPath = join(targetDir, 'config.toml');
+      const symlinkPath = join(tempDir, 'config.toml');
+
+      writeFileSync(targetPath, 'before\n', 'utf8');
+      chmodSync(targetPath, 0o640);
+      symlinkSync(targetPath, symlinkPath);
+
+      writeTextFileAtomically(symlinkPath, 'after\n');
+
+      assert.equal(readlinkSync(symlinkPath), targetPath);
+      assert.equal(readFileSync(targetPath, 'utf8'), 'after\n');
+      assert.equal(statSync(targetPath).mode & 0o777, 0o640);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/test-worker-auth-handoff-routes.ts
+++ b/test/unit/test-worker-auth-handoff-routes.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 
 import { handleWorkerAuthHandoffRoutes } from '../../src/server/worker-auth-handoff-routes.js';
+import { htmlResponse as secureHtmlResponse } from '../../src/server/worker-response-runtime.js';
 import { installNodeWebCryptoForTests } from '../utils/node-webcrypto.ts';
 
 installNodeWebCryptoForTests();
@@ -13,13 +14,13 @@ type FetchCall = { url: string; init?: RequestInit };
 
 const originalFetch = globalThis.fetch;
 
-function htmlResponse(html: string, _nonce?: string, extraHeaders?: HeadersInit): Response {
-  const headers = new Headers(extraHeaders);
-  headers.set('content-type', 'text/html; charset=utf-8');
-  return new Response(html, {
-    status: 200,
-    headers,
-  });
+function htmlResponse(
+  html: string,
+  nonce?: string,
+  extraHeaders?: HeadersInit,
+  securityOptions?: { formActionOrigins?: string[] },
+): Response {
+  return secureHtmlResponse(html, nonce ?? 'nonce', extraHeaders, securityOptions);
 }
 
 function jsonError(message: string, status: number, errorCode: string): Response {
@@ -819,10 +820,18 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     assert.ok(getResponse);
     assert.equal(getResponse.status, 200);
     assert.match(await getResponse.text(), /Approve OAuth access/);
+    const responseCookies = getResponse.headers.getSetCookie();
     const setCookie = String(getResponse.headers.get('set-cookie'));
     assert.match(setCookie, /clauth_approve=/);
     assert.match(setCookie, /clauth_flow=/);
     assert.match(setCookie, /clmcp_csrf=csrf-token-123/);
+    assert.ok(responseCookies.some((cookie) => cookie.startsWith('clauth_approve=')));
+    assert.ok(responseCookies.some((cookie) => cookie.startsWith('clauth_flow=')));
+    assert.ok(responseCookies.some((cookie) => cookie.startsWith('clmcp_csrf=csrf-token-123')));
+    assert.match(
+      getResponse.headers.get('content-security-policy') ?? '',
+      /form-action 'self' https:\/\/chatgpt\.com/,
+    );
     const approvalCorrelationId = getResponse.headers.get('x-hosted-auth-correlation-id');
     assert.match(String(approvalCorrelationId), /^[A-Za-z0-9_-]{8,}$/);
     assert.equal(completionCount, 0);

--- a/test/unit/test-worker-response-runtime.ts
+++ b/test/unit/test-worker-response-runtime.ts
@@ -46,6 +46,30 @@ describe('worker response runtime', () => {
     assert.ok((response.headers.get('content-security-policy') ?? '').includes(`nonce-${nonce}`));
   });
 
+  it('allows explicit callback origins in HTML form-action CSP', () => {
+    const response = htmlResponse('<html></html>', 'nonce', undefined, {
+      formActionOrigins: ['http://127.0.0.1:59547/callback', 'https://chatgpt.com/oauth/callback'],
+    });
+
+    assert.match(
+      response.headers.get('content-security-policy') ?? '',
+      /form-action 'self' http:\/\/127\.0\.0\.1:59547 https:\/\/chatgpt\.com/,
+    );
+  });
+
+  it('preserves multiple Set-Cookie headers passed into HTML responses', () => {
+    const extraHeaders = new Headers();
+    extraHeaders.append('Set-Cookie', 'first=value-1; Path=/; HttpOnly');
+    extraHeaders.append('Set-Cookie', 'second=value-2; Path=/; HttpOnly');
+
+    const response = htmlResponse('<html></html>', 'nonce', extraHeaders);
+    const cookies = response.headers.getSetCookie();
+
+    assert.equal(cookies.length, 2);
+    assert.equal(cookies[0], 'first=value-1; Path=/; HttpOnly');
+    assert.equal(cookies[1], 'second=value-2; Path=/; HttpOnly');
+  });
+
   it('preserves redirect location and security headers', () => {
     const response = redirectResponse('https://example.com/app', 302);
 


### PR DESCRIPTION
Supersedes #1546. This branch starts from main and applies the current dev tree so the promotion can merge cleanly without rewriting protected-branch history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted OAuth approval/response security headers (CSP and cookie handling) and the setup wizard’s config-writing behavior, which could break auth flows or client configs if incorrect. Changes are well-covered by new unit + e2e tests but still affect security-sensitive surfaces.
> 
> **Overview**
> **Codex CLI support:** Adds a `configs/codex.toml` template and updates the interactive `--setup` wizard to detect/configure the terminal Codex CLI by writing a *managed* TOML block into `~/.codex/config.toml`, backing up existing configs, handling pre-existing unmanaged sections, and redacting secrets in printed previews.
> 
> **Safer config writes:** Introduces `writeTextFileAtomically` for atomic writes that preserve symlink targets and existing file modes (defaulting new configs to `0600`).
> 
> **Hosted auth hardening:** Updates the worker HTML response path to (1) preserve multiple `Set-Cookie` headers when cloning/appending headers, and (2) allow explicit callback origins in CSP `form-action` for OAuth approvals (supporting loopback/external redirect URIs). Adds unit coverage plus a Playwright e2e that completes approval against a loopback callback origin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9054265187805cb64a097392e653afbf6879bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->