### PR TITLE
ci: route dependabot updates through dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Keep npm dependencies up to date
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       time: '09:00'
@@ -25,6 +26,7 @@ updates:
   # Keep GitHub Actions up to date
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       time: '09:30'


### PR DESCRIPTION
Set Dependabot target branches to `dev` for npm and GitHub Actions updates so recreated and rebased dependency PRs stop snapping back to `main` and follow the repo promotion path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that just alters the target branch for Dependabot PRs. Main impact is on the repo’s dependency update workflow, not runtime behavior.
> 
> **Overview**
> Routes automated dependency update PRs through `dev` by setting `target-branch: dev` for both the `npm` and `github-actions` Dependabot update configs in `.github/dependabot.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0a96791d1b0a9b0f572e51a70f567a92ba61b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to ensure GitHub Actions and npm dependencies are routed through the development branch for validation before production deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/courtlistener-mcp/pull/1549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->