### PR TITLE
chore: promote dev workflow dependency updates to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo "Skipping release-please because RELEASE_PLEASE_TOKEN is not configured."
 
       - if: ${{ steps.token-check.outputs.configured == 'true' }}
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: node
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
     environment: github-release
     steps:
       - uses: actions/checkout@v6
-      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
 


### PR DESCRIPTION
Promote the workflow dependency updates already merged on `dev` into `main` while preserving the newer `main` fixes for Dependabot target branches, promotion policy, and the callback-server CodeQL remediation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates major versions of release automation actions, which could change release behavior or permissions at publish time. Scope is limited to GitHub workflow configuration only.
> 
> **Overview**
> Updates release automation dependencies in GitHub Actions workflows by upgrading `googleapis/release-please-action` from v4 to v5 in `release-please.yml` and `softprops/action-gh-release` from v2 to v3 in `release.yml`.
> 
> No application code changes; impact is confined to how releases and release PRs are generated/published in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b8f961a34de49caee25628f6565055aa1834242. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->