### PR TITLE
fix: add webkit backdrop filter support

### DIFF
--- a/src/web-spa/src/styles/landing.css
+++ b/src/web-spa/src/styles/landing.css
@@ -53,6 +53,7 @@
   min-height: 72px;
   border-bottom: 1px solid var(--landing-color-border-light);
   background: rgba(255, 255, 255, 0.94);
+  -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
 }
 
@@ -312,6 +313,7 @@
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: rgba(7, 20, 38, 0.86);
   box-shadow: var(--landing-shadow-hero-card);
+  -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
 }
 

--- a/src/web-spa/src/styles/primitives.css
+++ b/src/web-spa/src/styles/primitives.css
@@ -249,6 +249,7 @@ a {
   border-radius: var(--surface-radius-xl);
   padding: 22px;
   box-shadow: var(--surface-shadow);
+  -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
 }
 
@@ -413,6 +414,7 @@ a {
   border-radius: var(--radius-md);
   background: var(--hero-note-bg);
   color: var(--landing-color-text-inverse);
+  -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
 }
 

--- a/src/web-spa/src/styles/workspace.css
+++ b/src/web-spa/src/styles/workspace.css
@@ -362,6 +362,7 @@
     border: 0;
     padding: 0;
     background: var(--shell-sidebar-overlay);
+    -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
   }
   .workspace-sidebar {


### PR DESCRIPTION
Summary
- add -webkit-backdrop-filter alongside existing backdrop blur rules in the SPA styles
- regenerate src/web/spa-assets.ts so the checked-in asset manifest matches the built SPA bundle

Testing
- pnpm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that adds a vendor-prefixed CSS property; main risk is minor cross-browser rendering/perf differences on affected blurred surfaces.
> 
> **Overview**
> Improves Safari/WebKit support for existing blur effects by adding `-webkit-backdrop-filter` alongside `backdrop-filter` on the landing header/code card, shared `ui-card`/`page-hero-note`, and the mobile sidebar backdrop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00df02d09fba824f59919c34422e287d1e70291. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->