### PR TITLE
fix: add webkit backdrop filter support

### DIFF
--- a/src/web-spa/src/styles/landing.css
+++ b/src/web-spa/src/styles/landing.css
@@ -53,6 +53,7 @@
   min-height: 72px;
   border-bottom: 1px solid var(--landing-color-border-light);
   background: rgba(255, 255, 255, 0.94);
+  -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
 }
 
@@ -312,6 +313,7 @@
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: rgba(7, 20, 38, 0.86);
   box-shadow: var(--landing-shadow-hero-card);
+  -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
 }
 

--- a/src/web-spa/src/styles/primitives.css
+++ b/src/web-spa/src/styles/primitives.css
@@ -249,6 +249,7 @@ a {
   border-radius: var(--surface-radius-xl);
   padding: 22px;
   box-shadow: var(--surface-shadow);
+  -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
 }
 
@@ -413,6 +414,7 @@ a {
   border-radius: var(--radius-md);
   background: var(--hero-note-bg);
   color: var(--landing-color-text-inverse);
+  -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
 }
 

--- a/src/web-spa/src/styles/workspace.css
+++ b/src/web-spa/src/styles/workspace.css
@@ -362,6 +362,7 @@
     border: 0;
     padding: 0;
     background: var(--shell-sidebar-overlay);
+    -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
   }
   .workspace-sidebar {


### PR DESCRIPTION
Summary
- add -webkit-backdrop-filter alongside existing backdrop blur rules in the SPA styles
- promote the regenerated src/web/spa-assets.ts artifact from dev to main

Testing
- pnpm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CSS-only vendor-prefix additions to improve backdrop blur rendering in WebKit/Safari without changing layout or JS behavior.
> 
> **Overview**
> Improves Safari/WebKit support for translucent “glass” surfaces by adding `-webkit-backdrop-filter` alongside existing `backdrop-filter` blur rules.
> 
> This applies to the landing header and code card (`landing.css`), generic cards and hero notes (`primitives.css`), and the mobile sidebar backdrop overlay (`workspace.css`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b4a59a91fb0cd17ec076493922dd9a7b1bac72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced backdrop blur visual effects on WebKit browsers (Safari, Chrome, Edge) across landing pages, hero sections, cards, and mobile sidebar components for improved cross-browser rendering consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/courtlistener-mcp/pull/1555)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->