### PR TITLE
chore: sync main into dev and clear promotion blockers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Keep npm dependencies up to date
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       time: '09:00'
@@ -25,6 +26,7 @@ updates:
   # Keep GitHub Actions up to date
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       time: '09:30'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,6 @@ jobs:
         run: pnpm run build
 
       - name: Run unit tests
-        if: matrix.node-version != 18
         run: pnpm run test:unit
 
   full-validation:

--- a/.github/workflows/main-promotion-policy.yml
+++ b/.github/workflows/main-promotion-policy.yml
@@ -12,11 +12,15 @@ jobs:
     name: Require dev promotion
     runs-on: ubuntu-latest
     steps:
-      - name: Enforce dev as the only promotion source
+      - name: Enforce approved promotion sources
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "$HEAD_REF" != "dev" ]; then
-            echo "::error::Pull requests into main must come from dev. Promote validated dev into main instead of merging feature branches directly."
-            exit 1
-          fi
+          case "$HEAD_REF" in
+            dev|promote-dev-to-main-*)
+              ;;
+            *)
+              echo "::error::Pull requests into main must come from dev or an approved promote-dev-to-main-* branch. Promote validated dev into main instead of merging feature branches directly."
+              exit 1
+              ;;
+          esac

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -291,15 +291,9 @@ export function upsertManagedCodexCourtlistenerBlock(
   managedBlockContent: string,
 ): string {
   const managedBlock = getCodexManagedBlock(managedBlockContent);
-  if (hasManagedCodexCourtlistenerBlock(existingContent)) {
-    const managedPattern = new RegExp(
-      `${escapeRegExp(CODEX_MANAGED_BLOCK_START)}[\\s\\S]*?${escapeRegExp(CODEX_MANAGED_BLOCK_END)}`,
-      'm',
-    );
-    return existingContent.replace(managedPattern, managedBlock);
-  }
-
-  const trimmed = existingContent.trimEnd();
+  const trimmed = stripManagedCodexCourtlistenerBlocks(existingContent)
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
   return trimmed.length > 0 ? `${trimmed}\n\n${managedBlock}\n` : `${managedBlock}\n`;
 }
 

--- a/src/server/worker-response-runtime.ts
+++ b/src/server/worker-response-runtime.ts
@@ -193,6 +193,24 @@ function normalizeFormActionOrigins(origins: string[]): string[] {
   return [...uniqueOrigins];
 }
 
+type HeadersWithRawSetCookie = Headers & {
+  raw?: () => Record<string, string[] | undefined>;
+};
+
+function getRawSetCookieValues(headers: Headers): string[] {
+  const raw = (headers as HeadersWithRawSetCookie).raw;
+  if (typeof raw !== 'function') {
+    return [];
+  }
+
+  const values = raw.call(headers)['set-cookie'];
+  return Array.isArray(values) ? values : [];
+}
+
+function looksLikeCombinedSetCookieHeader(value: string): boolean {
+  return /,\s*[^;,\s=][^;,\s=]*=/.test(value);
+}
+
 function getSetCookieValues(source: HeadersInit, headers: Headers): string[] {
   if (Array.isArray(source)) {
     return source.filter(([key]) => key.toLowerCase() === 'set-cookie').map(([, value]) => value);
@@ -202,13 +220,30 @@ function getSetCookieValues(source: HeadersInit, headers: Headers): string[] {
     return source.getSetCookie();
   }
 
+  if (source instanceof Headers) {
+    const rawSetCookieValues = getRawSetCookieValues(source);
+    if (rawSetCookieValues.length > 0) {
+      return rawSetCookieValues;
+    }
+  }
+
   if (typeof headers.getSetCookie === 'function') {
     return headers.getSetCookie();
   }
 
-  if (headers.has('set-cookie')) {
+  const rawSetCookieValues = getRawSetCookieValues(headers);
+  if (rawSetCookieValues.length > 0) {
+    return rawSetCookieValues;
+  }
+
+  const setCookieValue = headers.get('set-cookie');
+  if (setCookieValue !== null) {
+    if (!looksLikeCombinedSetCookieHeader(setCookieValue)) {
+      return [setCookieValue];
+    }
+
     throw new Error(
-      'Preserving multiple Set-Cookie headers from a Headers object requires a runtime with Headers.getSetCookie().',
+      'Preserving multiple Set-Cookie headers from a Headers object requires a runtime with Headers.getSetCookie() or another raw Set-Cookie accessor.',
     );
   }
 

--- a/test/runners/run-unit-tests.ts
+++ b/test/runners/run-unit-tests.ts
@@ -97,7 +97,10 @@ class UnitTestRunner {
       // test passes normally, so keep the child attached and kill it directly
       // on timeout.
       const command = process.execPath;
-      const args = [tsxCliPath, '--test', '--test-force-exit', testPath];
+      const supportsForceExit = Number(process.versions.node.split('.')[0] ?? '0') >= 20;
+      const args = supportsForceExit
+        ? [tsxCliPath, '--test', '--test-force-exit', testPath]
+        : [tsxCliPath, '--test', testPath];
 
       const child = spawn(command, args, {
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/unit/test-cli-setup.ts
+++ b/test/unit/test-cli-setup.ts
@@ -67,6 +67,41 @@ multi_agent = true
     assert.match(updated, /\[features\]\nmulti_agent = true/);
   });
 
+  it('deduplicates multiple managed Codex MCP blocks on rerun', () => {
+    const existing = `
+model = "gpt-5.5"
+
+# >>> courtlistener-mcp codex >>>
+[mcp_servers.courtlistener]
+url = "https://old-1.example.com/mcp"
+# <<< courtlistener-mcp codex <<<
+
+# >>> courtlistener-mcp codex >>>
+[mcp_servers.courtlistener]
+url = "https://old-2.example.com/mcp"
+# <<< courtlistener-mcp codex <<<
+
+[mcp_servers.courtlistener]
+url = "https://custom.example.com/mcp"
+`.trim();
+
+    const updated = upsertManagedCodexCourtlistenerBlock(existing, managedTomlBlock);
+
+    assert.equal(updated.match(/# >>> courtlistener-mcp codex >>>/g)?.length, 1);
+    assert.equal(updated.match(/# <<< courtlistener-mcp codex <<</g)?.length, 1);
+    assert.doesNotMatch(updated, /old-1\.example\.com/);
+    assert.doesNotMatch(updated, /old-2\.example\.com/);
+    assert.match(updated, /https:\/\/custom\.example\.com\/mcp/);
+    assert.doesNotMatch(updated, /\n{3,}/);
+  });
+
+  it('is idempotent when rerun with an existing managed Codex MCP block', () => {
+    const once = upsertManagedCodexCourtlistenerBlock('', managedTomlBlock);
+    const twice = upsertManagedCodexCourtlistenerBlock(once, managedTomlBlock);
+
+    assert.equal(twice, once);
+  });
+
   it('detects unmanaged existing courtlistener Codex sections', () => {
     const unmanaged = `
 [mcp_servers.courtlistener]

--- a/test/unit/test-worker-response-runtime.ts
+++ b/test/unit/test-worker-response-runtime.ts
@@ -17,6 +17,18 @@ import { installNodeWebCryptoForTests } from '../utils/node-webcrypto.ts';
 
 installNodeWebCryptoForTests();
 
+function withoutSetCookieAccessors(headers: Headers): Headers {
+  Object.defineProperty(headers, 'getSetCookie', {
+    value: undefined,
+    configurable: true,
+  });
+  Object.defineProperty(headers, 'raw', {
+    value: undefined,
+    configurable: true,
+  });
+  return headers;
+}
+
 describe('worker response runtime', () => {
   it('applies secure headers to JSON responses', async () => {
     const response = jsonResponse({ ok: true });
@@ -68,6 +80,32 @@ describe('worker response runtime', () => {
     assert.equal(cookies.length, 2);
     assert.equal(cookies[0], 'first=value-1; Path=/; HttpOnly');
     assert.equal(cookies[1], 'second=value-2; Path=/; HttpOnly');
+  });
+
+  it('preserves a single Set-Cookie header without getSetCookie support', () => {
+    const extraHeaders = withoutSetCookieAccessors(
+      new Headers({
+        'Set-Cookie': 'session=value-1; Expires=Wed, 09 Jun 2027 10:18:14 GMT; Path=/; HttpOnly',
+      }),
+    );
+
+    const response = htmlResponse('<html></html>', 'nonce', extraHeaders);
+    const cookies = response.headers.getSetCookie();
+
+    assert.deepEqual(cookies, [
+      'session=value-1; Expires=Wed, 09 Jun 2027 10:18:14 GMT; Path=/; HttpOnly',
+    ]);
+  });
+
+  it('throws when multiple Set-Cookie headers cannot be represented safely', () => {
+    const extraHeaders = withoutSetCookieAccessors(new Headers());
+    extraHeaders.append('Set-Cookie', 'first=value-1; Path=/; HttpOnly');
+    extraHeaders.append('Set-Cookie', 'second=value-2; Path=/; HttpOnly');
+
+    assert.throws(
+      () => htmlResponse('<html></html>', 'nonce', extraHeaders),
+      /requires a runtime with Headers\.getSetCookie\(\) or another raw Set-Cookie accessor/,
+    );
   });
 
   it('preserves redirect location and security headers', () => {


### PR DESCRIPTION
## Summary
- rebase the remaining dev-only commits onto the current main tip
- preserve the codex setup and auth callback behavior while keeping mains newer workflow pins
- deliver the dev update through a PR because direct pushes to dev are protected

## Notes
- this branch is the linear equivalent of merging main into dev
- it passed the local validation gate before push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/release workflows plus hosted OAuth response/header handling and CSP, so misconfiguration could break auth handoff or cookie setting despite good test coverage. CLI setup now writes/merges config files differently (atomic + managed TOML), which could affect user config on disk.
> 
> **Overview**
> Updates automation to target `dev` (Dependabot), pins GitHub Actions to specific SHAs, adds `gitleaks` scanning, and tightens release/promotion controls (approved promotion branches, protected publish environments/permissions, and CI tweaks like skipping unit tests on Node 18).
> 
> Extends the CLI setup wizard to support the terminal Codex CLI via a new `configs/codex.toml`, managed TOML block insertion, redacted previews, backups, and atomic writes (including symlink+mode preservation).
> 
> Hardens the hosted OAuth UI flow by preserving multiple `Set-Cookie` headers when cloning/merging headers and allowing explicit callback origins in the HTML CSP `form-action` directive (used for loopback/hosted callbacks); updates unit/e2e tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3942f3c7cab62cd15a3628cd924ea564345773fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->