### PR TITLE
chore: promote dev to main

### DIFF
--- a/configs/codex.json
+++ b/configs/codex.json
@@ -5,7 +5,7 @@
       "transport": "streamable-http",
       "auth": {
         "type": "oauth2",
-        "authorizationUrl": "https://courtlistenermcp.blakeoxford.com/authorize",
+        "authorizationUrl": "https://courtlistenermcp.blakeoxford.com/oauth/authorize",
         "tokenUrl": "https://courtlistenermcp.blakeoxford.com/token",
         "scopes": ["legal:read", "legal:search", "legal:analyze"]
       }

--- a/configs/cursor.json
+++ b/configs/cursor.json
@@ -7,6 +7,9 @@
       "env": {
         "COURTLISTENER_API_KEY": "your-api-key"
       }
+    },
+    "courtlistener-remote": {
+      "url": "https://courtlistenermcp.blakeoxford.com/mcp"
     }
   }
 }

--- a/configs/hosted-oauth-chatgpt.json
+++ b/configs/hosted-oauth-chatgpt.json
@@ -5,7 +5,7 @@
       "transport": "streamable-http",
       "auth": {
         "type": "oauth2",
-        "authorizationUrl": "https://your-deployment.example.com/authorize",
+        "authorizationUrl": "https://your-deployment.example.com/oauth/authorize",
         "tokenUrl": "https://your-deployment.example.com/token",
         "scopes": ["legal:read", "legal:search", "legal:analyze"]
       }

--- a/configs/hosted-oauth-codex.json
+++ b/configs/hosted-oauth-codex.json
@@ -5,7 +5,7 @@
       "transport": "streamable-http",
       "auth": {
         "type": "oauth2",
-        "authorizationUrl": "https://courtlistenermcp.blakeoxford.com/authorize",
+        "authorizationUrl": "https://courtlistenermcp.blakeoxford.com/oauth/authorize",
         "tokenUrl": "https://courtlistenermcp.blakeoxford.com/token",
         "scopes": ["legal:read", "legal:search", "legal:analyze"]
       }

--- a/configs/openai-chatgpt.json
+++ b/configs/openai-chatgpt.json
@@ -5,7 +5,7 @@
       "transport": "streamable-http",
       "auth": {
         "type": "oauth2",
-        "authorizationUrl": "https://your-deployment.example.com/authorize",
+        "authorizationUrl": "https://your-deployment.example.com/oauth/authorize",
         "tokenUrl": "https://your-deployment.example.com/token",
         "scopes": ["legal:read", "legal:search", "legal:analyze"]
       }

--- a/docs/testing/E2E_AUTH_CHAT_FLOW.md
+++ b/docs/testing/E2E_AUTH_CHAT_FLOW.md
@@ -5,7 +5,8 @@ This test verifies the deployed Worker-owned hosted OAuth handshake:
 1. Fetch authorization-server metadata
 2. Fetch protected-resource metadata
 3. Register a public OAuth client
-4. Request `/authorize`
+4. Request `/oauth/authorize` (not legacy `/authorize`, which may hit Cloudflare
+   Access)
 5. Verify redirect into same-origin Worker `/auth/start`
 6. Verify hosted-auth readiness headers and handoff page behavior
 

--- a/src/web-spa/DESIGN.md
+++ b/src/web-spa/DESIGN.md
@@ -42,7 +42,7 @@ styles.css
 | ------------------------- | ------------------------------------------------------------------------------------------------------- |
 | New layout/spacing in TSX | Tailwind utilities (`flex`, `gap-3`, `p-4`, `md:grid-cols-2`)                                           |
 | New colors in TSX         | Theme utilities (`text-ink`, `bg-card`, `text-accent`, `dark:bg-bg-soft`)                               |
-| Reusable component look   | Semantic class in `primitives.css` / `workspace.css` (optionally with `@apply`)                         |
+| Reusable component look   | Export a recipe from `lib/*-classes.ts` and compose with `cn()` in TSX                                  |
 | New color value           | Add to `tokens.css` (+ dark override), then wire in `theme.css` `@theme inline` if utilities are needed |
 
 **Rule of thumb:** primary actions → shell blue (`btn primary` or `bg` utilities
@@ -86,21 +86,45 @@ component CSS for complex grids.
 npm run dev:spa
 ```
 
-Opens Vite at `http://127.0.0.1:5173`. API routes proxy to
-`http://localhost:3001` when a worker is running locally.
+Opens Vite at `http://127.0.0.1:5173`. Worker routes (`/api`, `/auth`, `/oauth`,
+`/mcp`, `/health`, `/.well-known`, …) proxy to `http://localhost:3001` when
+`wrangler dev` (or the local HTTP transport) is running — required for hosted
+sign-in and MCP OAuth from the dev SPA.
 
 ## Checks
 
 ```bash
 pnpm run ci:check:design-system   # Tailwind wired, class-recipe modules, token-only CSS, production CSS budget
-npm run test:spa                 # Vitest (includes design-system-compliance)
-npm run test:spa:design          # Playwright layout/token smoke (landing grid, chat, transcript)
+npm run test:spa                 # Vitest (design-system wiring; skips production build — see below)
+npm run test:spa:design          # Playwright layout/token smoke (landing, workspace, usage, observability, …)
 ```
 
 The design-system script also verifies class-recipe modules export hook classes
 (`landing-page`, `stack`, `chat-stream`, …), require `cn()` composition, block
 raw layout class strings in workspace page TSX, and fail if the production CSS
 bundle exceeds **92 kB** (builds the SPA as part of the check).
+
+`ci:local-gate` and CI Full Validation run the full check (including the
+production build + CSS budget). Vitest sets
+`DESIGN_SYSTEM_SKIP_PRODUCTION_BUILD=1` so `test:spa` does not run a second Vite
+production build.
+
+## Composing classes with `cn()` and `tailwind-merge`
+
+Class recipes live in `lib/*-classes.ts` and are composed with `cn()` from
+`lib/cn.ts` (`tailwind-merge`).
+
+**Hook classes last:** stable selectors used by tests and Playwright smoke
+(`text-link`, `ui-card`, `stack`, `chat-stream`, …) must appear **after**
+conflicting Tailwind utilities in `cn()`, or `tailwind-merge` may drop them.
+Example from `ui-classes.ts`:
+
+```ts
+export const textLinkClass = cn(
+  'font-semibold text-accent underline …',
+  'text-link', // hook class — keep last
+);
+```
 
 ## Adding a new style
 
@@ -120,21 +144,25 @@ bundle exceeds **92 kB** (builds the SPA as part of the check).
    `lib/workspace-classes.ts`.
 9. Run `npm run test:spa` and `npm run test:spa:design`.
 
-## Common classes (semantic layer)
+## Hook classes (stable selectors)
 
-| Class                          | Role                         |
-| ------------------------------ | ---------------------------- |
-| `.btn.primary`                 | Blue gradient primary action |
-| `.nav-card-link.active`        | Shell sidebar active item    |
-| `.page-hero`                   | In-app hero panel            |
-| `.ui-card` / `.card-spotlight` | Content cards                |
-| `.eyebrow-label`               | Section label above headings |
-| `.text-link`                   | Accent-colored inline link   |
-| `.landing-page`                | Marketing root wrapper       |
+Recipes in `*-classes.ts` attach **hook class names** alongside Tailwind
+utilities. These are not defined in component CSS anymore; they exist for tests,
+Playwright smoke, and debugging.
 
-Shared primitives in `ui.tsx` are migrated to `ui-classes.ts`. Landing layout
-uses `landing-classes.ts` + `landing-layout.tsx`; Playground chat/transcript
-uses `playground-classes.ts`. Component CSS (`landing.css`, `primitives.css`)
-keeps marketing nav colors, setup tabs, code syntax, and other patterns not yet
-ported. Compose with `cn()` and keep hook class names (`ui-card`, `btn`,
-`text-link`, `chat-stream`, `transcript-entry`, …) for tests.
+| Hook class               | Module                  | Role                         |
+| ------------------------ | ----------------------- | ---------------------------- |
+| `btn` / `primary`        | `ui-classes.ts`         | Primary shell action         |
+| `nav-card-link`          | `shell-classes.ts`      | Sidebar navigation item      |
+| `page-hero`              | `ui-classes.ts`         | In-app hero panel            |
+| `ui-card`                | `ui-classes.ts`         | Content card shell           |
+| `eyebrow-label`          | `ui-classes.ts`         | Section label above headings |
+| `text-link`              | `ui-classes.ts`         | Accent inline link           |
+| `landing-page`           | `landing-classes.ts`    | Marketing root wrapper       |
+| `stack` / `two-col`      | `workspace-classes.ts`  | Workspace page layout        |
+| `chat-stream`            | `playground-classes.ts` | Playground chat column       |
+| `table` / `table-scroll` | `workspace-classes.ts`  | Usage route table            |
+
+`primitives.css` and `landing.css` / `workspace.css` hold only global resets and
+reserved placeholders — not component layout. Add new UI via the matching
+`*-classes.ts` module and compose with `cn()`.

--- a/src/web-spa/e2e/design-smoke.spec.ts
+++ b/src/web-spa/e2e/design-smoke.spec.ts
@@ -171,6 +171,62 @@ test.describe('Design system smoke', () => {
     await expect(page.locator('.stack').first()).toBeVisible();
   });
 
+  test('workspace usage page uses stack and table layout classes', async ({ page }) => {
+    await installSpaMocks(page, {
+      session: {
+        authenticated: true,
+        user: { id: 'operator-1' },
+        turnstile_site_key: '',
+      },
+      usage: {
+        userId: 'operator-1',
+        totalRequests: 17,
+        dailyRequests: 4,
+        currentDay: '2026-04-23',
+        lastSeenAt: '2026-04-23T20:45:00.000Z',
+        byRoute: {
+          '/mcp': 11,
+          '/api/session': 6,
+        },
+        browserBootstrap: {
+          attempted: 2,
+          succeeded: 1,
+          failed: 1,
+          turnstileRefreshed: 0,
+          lastOutcome: 'success',
+          lastEventAt: '2026-04-23T20:40:00.000Z',
+        },
+      },
+    });
+
+    await page.goto('/app/usage');
+    await expect(page.getByRole('heading', { name: 'Usage & History', level: 1 })).toBeVisible();
+    await expect(page.locator('.stack').first()).toBeVisible();
+    await expect(page.locator('.table-scroll')).toBeVisible();
+    await expect(page.locator('.table')).toBeVisible();
+  });
+
+  test('workspace observability page uses stack layout and worker health tokens', async ({
+    page,
+  }) => {
+    await installSpaMocks(page, {
+      session: {
+        authenticated: true,
+        user: { id: 'operator-1' },
+        turnstile_site_key: '',
+      },
+    });
+
+    await page.goto('/app/observability');
+    await expect(
+      page.getByRole('heading', { name: 'Agent Observability', level: 1 }),
+    ).toBeVisible();
+    await expect(page.locator('.stack').first()).toBeVisible();
+    await expect(page.locator('.two-up-grid')).toBeVisible();
+    await expect(page.locator('.two-col')).toBeVisible();
+    await expect(page.locator('ul.ordered').first()).toBeVisible();
+  });
+
   test('playground exposes eyebrow label typography class', async ({ page }) => {
     await installSpaMocks(page, {
       session: {

--- a/src/web-spa/e2e/support/mock-backend.ts
+++ b/src/web-spa/e2e/support/mock-backend.ts
@@ -1,5 +1,5 @@
 import type { Page, Route } from 'playwright/test';
-import { sessionSchema, usageSnapshotSchema } from '../../src/lib/api';
+import { sessionSchema, usageSnapshotSchema, workerHealthSchema } from '../../src/lib/api';
 
 interface MockSessionResponse {
   authenticated: boolean;
@@ -21,6 +21,28 @@ interface MockUsageSnapshot {
     turnstileRefreshed: number;
     lastOutcome: string | null;
     lastEventAt: string | null;
+  };
+}
+
+interface MockWorkerHealth {
+  status: 'ok';
+  service: 'courtlistener-mcp';
+  transport: 'cloudflare-agents-streamable-http';
+  cloudflare: {
+    analytics_enabled: boolean;
+    async_queue_configured: boolean;
+    async_jobs_kv_configured: boolean;
+    turnstile_enforced_routes: string[];
+  };
+  metrics: {
+    latency_ms: Record<string, unknown>;
+  };
+  session_topology: {
+    version: string;
+    shard_count: number;
+    idle_ttl_ms: number;
+    absolute_ttl_ms: number;
+    eviction_sweep_limit: number;
   };
 }
 
@@ -52,6 +74,7 @@ interface MockRuntimeCatalog {
 interface InstallSpaMocksOptions {
   session?: MockSessionResponse;
   usage?: MockUsageSnapshot;
+  health?: MockWorkerHealth;
   runtime?: MockRuntimeCatalog;
   sessionFailure?: {
     status?: number;
@@ -89,13 +112,42 @@ async function fulfillJson(
   });
 }
 
-function validateMockContract(type: 'session' | 'usage', body: unknown): void {
+function validateMockContract(type: 'session' | 'usage' | 'health', body: unknown): void {
   if (type === 'session') {
     sessionSchema.parse(body);
     return;
   }
+  if (type === 'health') {
+    workerHealthSchema.parse(body);
+    return;
+  }
   usageSnapshotSchema.parse(body);
 }
+
+const defaultWorkerHealth: MockWorkerHealth = {
+  status: 'ok',
+  service: 'courtlistener-mcp',
+  transport: 'cloudflare-agents-streamable-http',
+  cloudflare: {
+    analytics_enabled: true,
+    async_queue_configured: true,
+    async_jobs_kv_configured: true,
+    turnstile_enforced_routes: ['session_bootstrap', 'ai_chat'],
+  },
+  metrics: {
+    latency_ms: {
+      route_latency_ms: { '/mcp': { count: 4, avg_ms: 120 } },
+      runtime_latency_ms: { queue_latency_ms: { count: 2, avg_ms: 40 } },
+    },
+  },
+  session_topology: {
+    version: 'v1',
+    shard_count: 4,
+    idle_ttl_ms: 1_800_000,
+    absolute_ttl_ms: 43_200_000,
+    eviction_sweep_limit: 100,
+  },
+};
 
 export async function seedBrowserToken(page: Page, token: string, persist = false): Promise<void> {
   await page.addInitScript(
@@ -122,6 +174,7 @@ export async function installSpaMocks(
     user: null,
     turnstile_site_key: '',
   };
+  const health = options.health ?? defaultWorkerHealth;
   const usage = options.usage ?? {
     userId: sessionState.user?.id ?? 'signed-out',
     totalRequests: 0,
@@ -162,6 +215,11 @@ export async function installSpaMocks(
   await page.route('**/api/usage', async (route) => {
     validateMockContract('usage', usage);
     await fulfillJson(route, usage);
+  });
+
+  await page.route('**/health', async (route) => {
+    validateMockContract('health', health);
+    await fulfillJson(route, health);
   });
 
   await page.route('**/api/logout', async (route) => {

--- a/src/web-spa/vite.config.ts
+++ b/src/web-spa/vite.config.ts
@@ -3,6 +3,27 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
+/** Local Worker (`wrangler dev` / HTTP transport on port 3001). */
+const workerDevTarget = 'http://localhost:3001';
+
+const workerDevProxy = {
+  target: workerDevTarget,
+  changeOrigin: true,
+} as const;
+
+/** Worker-owned routes required for hosted sign-in and MCP OAuth during SPA dev. */
+const workerDevProxyPrefixes = [
+  '/api',
+  '/mcp',
+  '/sse',
+  '/auth',
+  '/oauth',
+  '/token',
+  '/register',
+  '/health',
+  '/.well-known',
+] as const;
+
 export default defineConfig({
   root: path.resolve(__dirname),
   plugins: [react(), tailwindcss()],
@@ -17,15 +38,6 @@ export default defineConfig({
   },
   server: {
     port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
-      },
-      '/mcp': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
-      },
-    },
+    proxy: Object.fromEntries(workerDevProxyPrefixes.map((prefix) => [prefix, workerDevProxy])),
   },
 });


### PR DESCRIPTION
## Summary
- promote the merged dev follow-up fixes into main
- carry over the SPA design-system smoke coverage improvements
- carry over the hosted OAuth dev-proxy and config/doc updates

## Validation
- PR #1565 merged into dev after the required checks passed
- promotion branch built from origin/main with the origin/dev tree squashed in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to configuration/docs, SPA dev-server proxy settings, and Playwright test/mocking updates with no production runtime logic changes.
> 
> **Overview**
> Updates hosted OAuth examples and E2E docs to use `/oauth/authorize` instead of the legacy `/authorize`, and adds a `courtlistener-remote` entry to the Cursor MCP config.
> 
> Expands the SPA Vite dev-server proxy from just `/api` and `/mcp` to all Worker-owned routes needed for local hosted sign-in/MCP OAuth (e.g. `/auth`, `/oauth`, `/health`, `/.well-known`).
> 
> Strengthens SPA design-system smoke coverage by adding workspace `Usage`/`Observability` page assertions and extending the Playwright mock backend to serve and validate a default `/health` response via `workerHealthSchema`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40c4d0bbe0ed4638df2f8bbda0f27ac50a3c3742. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth authorization endpoint configurations across multiple deployment environments.
  * Refactored development proxy configuration for improved maintainability.

* **Documentation**
  * Enhanced design system architecture guidance and styling practices.
  * Updated end-to-end authentication testing documentation.

* **Tests**
  * Added end-to-end test coverage for workspace usage and observability pages.
  * Extended mock data support for health monitoring validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/courtlistener-mcp/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->