### PR TITLE
chore: promote dev to main

### DIFF
--- a/src/server/worker-auth-handoff-routes.ts
+++ b/src/server/worker-auth-handoff-routes.ts
@@ -37,6 +37,7 @@ const AUTH_FLOW_COOKIE_NAME = 'clauth_flow';
 const CSRF_COOKIE_NAME = 'clmcp_csrf';
 const AUTH_STATE_TTL_SECONDS = 10 * 60;
 const AUTH_APPROVAL_TTL_SECONDS = 10 * 60;
+const AUTH_APPROVAL_COOKIE_SAMESITE: CookieSameSite = 'Lax';
 const AUTH_FLOW_TTL_SECONDS = 12 * 60 * 60;
 const DEFAULT_AUTH_SUCCESS_PATH = '/app/account';
 const UPSTREAM_DISCOVERY_TIMEOUT_MS = 5000;
@@ -956,6 +957,7 @@ interface AuthApprovalPayload {
 
 interface AuthFlowPayload {
   correlationId: string;
+  returnTo?: string;
   exp: number;
 }
 
@@ -1151,7 +1153,7 @@ async function encodeAuthApprovalCookie(
     signature,
     secure,
     AUTH_APPROVAL_TTL_SECONDS,
-    'Strict',
+    AUTH_APPROVAL_COOKIE_SAMESITE,
   );
 }
 
@@ -1221,7 +1223,8 @@ async function decodeAuthFlowCookie(
       typeof payload.correlationId !== 'string' ||
       typeof payload.exp !== 'number' ||
       !isSafeCorrelationId(payload.correlationId) ||
-      payload.exp <= Math.floor(Date.now() / 1000)
+      payload.exp <= Math.floor(Date.now() / 1000) ||
+      (payload.returnTo !== undefined && typeof payload.returnTo !== 'string')
     ) {
       return null;
     }
@@ -1758,6 +1761,8 @@ function renderAuthApprovalPage(params: {
   redirectUriHost: string | null;
   scope: string[];
   csrfToken: string;
+  returnTo: string;
+  approveAction: string;
   logoutHref: string;
   nonce: string;
 }): string {
@@ -1789,8 +1794,9 @@ function renderAuthApprovalPage(params: {
     `,
     actionsHtml: `
       <div class="auth-form-actions">
-        <form class="auth-inline-form" method="post" action="${HOSTED_MCP_BROWSER_AUTH_CONTRACT.paths.approve}">
+        <form class="auth-inline-form" method="post" action="${escapeHtml(params.approveAction)}">
           <input type="hidden" name="csrf_token" value="${escapeHtml(params.csrfToken)}" />
+          <input type="hidden" name="return_to" value="${escapeHtml(params.returnTo)}" />
           <button class="auth-button auth-button-primary" type="submit">Approve and continue</button>
         </form>
         ${renderAuthButtonLink(params.logoutHref, 'Sign out instead', 'secondary')}
@@ -1836,6 +1842,20 @@ function isDirectOauthReturnTarget(request: Request, returnTo: string): boolean 
   } catch {
     return false;
   }
+}
+
+function resolveEffectiveApprovalReturnTo(
+  request: Request,
+  candidates: Array<string | null | undefined>,
+): string | null {
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim();
+    if (!trimmed) continue;
+    if (isDirectOauthReturnTarget(request, trimmed)) {
+      return trimmed;
+    }
+  }
+  return null;
 }
 
 function buildAuthApprovalUrl(request: Request, returnTo: string): string {
@@ -1982,6 +2002,8 @@ async function buildApprovalPageResponse<
     headers.append('Set-Cookie', csrfCookieHeader);
   }
   const nonce = deps.generateCspNonce();
+  const approveActionUrl = new URL(HOSTED_MCP_BROWSER_AUTH_CONTRACT.paths.approve, request.url);
+  approveActionUrl.searchParams.set('return_to', returnTo);
 
   return deps.htmlResponse(
     renderAuthApprovalPage({
@@ -1989,6 +2011,8 @@ async function buildApprovalPageResponse<
       redirectUriHost: redirectUri?.host || null,
       scope: Array.isArray(authRequest.scope) ? authRequest.scope : [],
       csrfToken,
+      returnTo,
+      approveAction: `${approveActionUrl.pathname}${approveActionUrl.search}`,
       logoutHref: buildLogoutUrl(request, returnTo),
       nonce,
     }),
@@ -2159,6 +2183,7 @@ async function resolveHostedAuthCorrelationId<TEnv extends WorkerUiSessionRuntim
   env: TEnv,
   deps: Pick<HandleWorkerAuthHandoffRoutesDeps<TEnv>, 'workerUiSessionRuntime'>,
   candidates: Array<string | null | undefined> = [],
+  options?: { returnTo?: string | null },
 ): Promise<{ correlationId: string | null; setCookieHeader: string | null }> {
   const secret = deps.workerUiSessionRuntime.getUiSessionSecret(env);
   const secure = getSecureCookieSetting(request, env, deps);
@@ -2169,11 +2194,13 @@ async function resolveHostedAuthCorrelationId<TEnv extends WorkerUiSessionRuntim
     if (!secret) {
       return { correlationId: normalized, setCookieHeader: null };
     }
+    const returnTo = resolveEffectiveApprovalReturnTo(request, [options?.returnTo]);
     return {
       correlationId: normalized,
       setCookieHeader: await encodeAuthFlowCookie(
         {
           correlationId: normalized,
+          ...(returnTo ? { returnTo } : {}),
           exp: Math.floor(Date.now() / 1000) + AUTH_FLOW_TTL_SECONDS,
         },
         secret,
@@ -2188,6 +2215,24 @@ async function resolveHostedAuthCorrelationId<TEnv extends WorkerUiSessionRuntim
 
   const persisted = await decodeAuthFlowCookie(request, secret);
   if (persisted?.correlationId) {
+    const returnTo = resolveEffectiveApprovalReturnTo(request, [
+      options?.returnTo,
+      persisted.returnTo,
+    ]);
+    if (returnTo && returnTo !== persisted.returnTo) {
+      return {
+        correlationId: persisted.correlationId,
+        setCookieHeader: await encodeAuthFlowCookie(
+          {
+            correlationId: persisted.correlationId,
+            returnTo,
+            exp: Math.floor(Date.now() / 1000) + AUTH_FLOW_TTL_SECONDS,
+          },
+          secret,
+          secure,
+        ),
+      };
+    }
     return { correlationId: persisted.correlationId, setCookieHeader: null };
   }
 
@@ -2356,7 +2401,10 @@ export async function handleWorkerAuthHandoffRoutes<
     headers.append('Set-Cookie', buildExpiredCookie('clmcp_ui', secure, 'Lax'));
     headers.append('Set-Cookie', buildExpiredCookie('clmcp_ui_present', secure, 'Lax'));
     headers.append('Set-Cookie', buildExpiredCookie(AUTH_STATE_COOKIE_NAME, secure, 'Lax'));
-    headers.append('Set-Cookie', buildExpiredCookie(AUTH_APPROVAL_COOKIE_NAME, secure, 'Strict'));
+    headers.append(
+      'Set-Cookie',
+      buildExpiredCookie(AUTH_APPROVAL_COOKIE_NAME, secure, AUTH_APPROVAL_COOKIE_SAMESITE),
+    );
     headers.append('Set-Cookie', buildExpiredCookie(AUTH_FLOW_COOKIE_NAME, secure, 'Lax'));
     headers.append('Set-Cookie', buildExpiredCookie(CSRF_COOKIE_NAME, secure, 'Lax'));
     const response = buildRedirectResponse(
@@ -2937,12 +2985,19 @@ export async function handleWorkerAuthHandoffRoutes<
   }
 
   if (isHostedApprovalPath(url.pathname) && request.method === 'GET') {
-    const approveCorrelation = requestCorrelation.correlationId
-      ? requestCorrelation
-      : await resolveHostedAuthCorrelationId(request, env, deps, [createHostedAuthCorrelationId()]);
     const resolvedReturnTo = resolveAuthStartReturnTarget(
       request,
       url.searchParams.get('return_to'),
+    );
+    const approveCorrelation = await resolveHostedAuthCorrelationId(
+      request,
+      env,
+      deps,
+      [
+        requestCorrelation.correlationId,
+        ...(requestCorrelation.correlationId ? [] : [createHostedAuthCorrelationId()]),
+      ],
+      { returnTo: resolvedReturnTo.value },
     );
     if (!isDirectOauthReturnTarget(request, resolvedReturnTo.value)) {
       const nonce = deps.generateCspNonce();
@@ -3148,7 +3203,11 @@ export async function handleWorkerAuthHandoffRoutes<
     const initialApproveCorrelation = requestCorrelation.correlationId
       ? requestCorrelation
       : await resolveHostedAuthCorrelationId(request, env, deps, [createHostedAuthCorrelationId()]);
-    const clearApprovalCookie = buildExpiredCookie(AUTH_APPROVAL_COOKIE_NAME, secure, 'Strict');
+    const clearApprovalCookie = buildExpiredCookie(
+      AUTH_APPROVAL_COOKIE_NAME,
+      secure,
+      AUTH_APPROVAL_COOKIE_SAMESITE,
+    );
     if (!sessionSecret) {
       const response = deps.jsonError('Hosted auth is not configured.', 503, 'auth_not_configured');
       response.headers.append('Set-Cookie', clearApprovalCookie);
@@ -3206,46 +3265,19 @@ export async function handleWorkerAuthHandoffRoutes<
       return attachHostedAuthHeaders(response, signal);
     }
 
-    const approvalState = await decodeAuthApprovalCookie(request, sessionSecret);
-    const approvalCorrelation = await resolveHostedAuthCorrelationId(request, env, deps, [
-      approvalState?.correlationId,
-      initialApproveCorrelation.correlationId,
-    ]);
-    if (!approvalState || !isDirectOauthReturnTarget(request, approvalState.returnTo)) {
-      const response = deps.jsonError(
-        'Approval state is invalid or expired.',
-        400,
-        'invalid_approval_state',
-      );
-      response.headers.append('Set-Cookie', clearApprovalCookie);
-      if (approvalCorrelation.setCookieHeader) {
-        response.headers.append('Set-Cookie', approvalCorrelation.setCookieHeader);
-      }
-      const signal = withHostedAuthRequestDuration(
-        {
-          ...signalBase,
-          ready: false,
-          status: 'invalid_return_target' as const,
-          outcome: 'rejected' as const,
-          correlationId: approvalCorrelation.correlationId,
-          authError: 'invalid_approval_state',
-          approvalDurationMs: getElapsedDurationMs(requestStartedAtMs),
-        },
-        requestStartedAtMs,
-      );
-      emitHostedAuthEvent(
-        env,
-        request,
-        'hosted_auth.approve.reject',
-        { reason: 'invalid_approval_state' },
-        signal,
-      );
-      return attachHostedAuthHeaders(response, signal);
-    }
-
     const form = await request.formData();
     const csrfToken =
       typeof form.get('csrf_token') === 'string' ? String(form.get('csrf_token')).trim() : '';
+    const formReturnTo =
+      typeof form.get('return_to') === 'string' ? String(form.get('return_to')).trim() : '';
+    const queryReturnTo = url.searchParams.get('return_to')?.trim() || '';
+    const approvalState = await decodeAuthApprovalCookie(request, sessionSecret);
+    const flowState = await decodeAuthFlowCookie(request, sessionSecret);
+    const approvalCorrelation = await resolveHostedAuthCorrelationId(request, env, deps, [
+      approvalState?.correlationId,
+      initialApproveCorrelation.correlationId,
+      flowState?.correlationId,
+    ]);
     if (!csrfToken || csrfToken !== (getCookieValue(request, CSRF_COOKIE_NAME) ?? '')) {
       const response = deps.jsonError(
         'CSRF token validation failed.',
@@ -3278,11 +3310,86 @@ export async function handleWorkerAuthHandoffRoutes<
       return attachHostedAuthHeaders(response, signal);
     }
 
+    const submittedReturnTo = resolveEffectiveApprovalReturnTo(request, [
+      queryReturnTo,
+      formReturnTo,
+    ]);
+    const effectiveReturnTo =
+      submittedReturnTo ??
+      resolveEffectiveApprovalReturnTo(request, [flowState?.returnTo, approvalState?.returnTo]);
+    if (
+      submittedReturnTo &&
+      approvalState?.returnTo &&
+      isDirectOauthReturnTarget(request, approvalState.returnTo) &&
+      submittedReturnTo !== approvalState.returnTo
+    ) {
+      const response = deps.jsonError(
+        'Approval state is invalid or expired.',
+        400,
+        'invalid_approval_state',
+      );
+      response.headers.append('Set-Cookie', clearApprovalCookie);
+      if (approvalCorrelation.setCookieHeader) {
+        response.headers.append('Set-Cookie', approvalCorrelation.setCookieHeader);
+      }
+      const signal = withHostedAuthRequestDuration(
+        {
+          ...signalBase,
+          ready: false,
+          status: 'invalid_return_target' as const,
+          outcome: 'rejected' as const,
+          correlationId: approvalCorrelation.correlationId,
+          authError: 'invalid_approval_state',
+          approvalDurationMs: getElapsedDurationMs(requestStartedAtMs),
+        },
+        requestStartedAtMs,
+      );
+      emitHostedAuthEvent(
+        env,
+        request,
+        'hosted_auth.approve.reject',
+        { reason: 'approval_state_mismatch' },
+        signal,
+      );
+      return attachHostedAuthHeaders(response, signal);
+    }
+    if (!effectiveReturnTo) {
+      const response = deps.jsonError(
+        'Approval state is invalid or expired.',
+        400,
+        'invalid_approval_state',
+      );
+      response.headers.append('Set-Cookie', clearApprovalCookie);
+      if (approvalCorrelation.setCookieHeader) {
+        response.headers.append('Set-Cookie', approvalCorrelation.setCookieHeader);
+      }
+      const signal = withHostedAuthRequestDuration(
+        {
+          ...signalBase,
+          ready: false,
+          status: 'invalid_return_target' as const,
+          outcome: 'rejected' as const,
+          correlationId: approvalCorrelation.correlationId,
+          authError: 'invalid_approval_state',
+          approvalDurationMs: getElapsedDurationMs(requestStartedAtMs),
+        },
+        requestStartedAtMs,
+      );
+      emitHostedAuthEvent(
+        env,
+        request,
+        'hosted_auth.approve.reject',
+        { reason: 'invalid_approval_state' },
+        signal,
+      );
+      return attachHostedAuthHeaders(response, signal);
+    }
+
     try {
       const approvalStartedAtMs = Date.now();
       const response = await completeHostedAuthorization(
         env,
-        approvalState.returnTo,
+        effectiveReturnTo,
         sessionState.userId,
         deps,
       );
@@ -3306,7 +3413,7 @@ export async function handleWorkerAuthHandoffRoutes<
         request,
         'hosted_auth.approve.completed',
         {
-          return_to: approvalState.returnTo,
+          return_to: effectiveReturnTo,
         },
         signal,
       );

--- a/src/web-spa/e2e/real-auth-flow.spec.ts
+++ b/src/web-spa/e2e/real-auth-flow.spec.ts
@@ -163,6 +163,33 @@ test.describe('SPA real auth flow', () => {
     expect(callbackUrl.searchParams.get('state')).toBe('state-1');
   });
 
+  test('completes OAuth when the approval cookie is missing but return_to is posted', async ({
+    page,
+  }) => {
+    await bootstrapSession(page);
+
+    const authorizeUrl = new URL('/oauth/authorize', server.baseUrl);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', 'client-1');
+    authorizeUrl.searchParams.set('redirect_uri', `${server.baseUrl}/client/callback`);
+    authorizeUrl.searchParams.set('state', 'state-1');
+    authorizeUrl.searchParams.set('scope', 'legal:read');
+    authorizeUrl.searchParams.set('code_challenge', 'challenge');
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+
+    await page.goto(authorizeUrl.toString());
+    await expect(page.getByRole('heading', { name: 'Approve OAuth access' })).toBeVisible();
+
+    const cookies = await page.context().cookies(server.baseUrl);
+    await page.context().clearCookies();
+    await page.context().addCookies(cookies.filter((cookie) => cookie.name !== 'clauth_approve'));
+
+    await page.getByRole('button', { name: 'Approve and continue' }).click();
+
+    await page.waitForURL(/\/client\/callback\?/);
+    await expect(page.getByRole('heading', { name: 'Authorization completed' })).toBeVisible();
+  });
+
   test('allows approval to complete against a loopback callback origin', async ({ page }) => {
     await bootstrapSession(page);
 

--- a/test/unit/test-worker-auth-handoff-routes.ts
+++ b/test/unit/test-worker-auth-handoff-routes.ts
@@ -819,10 +819,15 @@ describe('handleWorkerAuthHandoffRoutes', () => {
 
     assert.ok(getResponse);
     assert.equal(getResponse.status, 200);
-    assert.match(await getResponse.text(), /Approve OAuth access/);
+    const approvalHtml = await getResponse.text();
+    assert.match(approvalHtml, /Approve OAuth access/);
+    assert.match(approvalHtml, /name="return_to"/);
+    assert.match(approvalHtml, /action="\/oauth\/approve\?return_to=/);
+    assert.match(approvalHtml, /worker\.example\/authorize\?/);
     const responseCookies = getResponse.headers.getSetCookie();
     const setCookie = String(getResponse.headers.get('set-cookie'));
     assert.match(setCookie, /clauth_approve=/);
+    assert.match(setCookie, /SameSite=Lax/);
     assert.match(setCookie, /clauth_flow=/);
     assert.match(setCookie, /clmcp_csrf=csrf-token-123/);
     assert.ok(responseCookies.some((cookie) => cookie.startsWith('clauth_approve=')));
@@ -876,11 +881,11 @@ describe('handleWorkerAuthHandoffRoutes', () => {
       },
     });
 
-    assert.equal(invalidPostResponse.status, 400);
-    assert.equal(invalidPostResponse.headers.get('x-hosted-auth-error'), 'invalid_approval_state');
+    assert.equal(invalidPostResponse.status, 403);
+    assert.equal(invalidPostResponse.headers.get('x-hosted-auth-error'), 'csrf_validation_failed');
     assert.equal(invalidPostResponse.headers.get('x-hosted-auth-route'), 'auth-approve');
     assert.equal(invalidPostResponse.headers.get('x-hosted-auth-outcome'), 'rejected');
-    assert.equal(invalidPostResponse.headers.get('x-hosted-auth-category'), 'request_validation');
+    assert.equal(invalidPostResponse.headers.get('x-hosted-auth-category'), 'security');
     assert.equal(completionCount, 0);
 
     const approvalCookie = setCookie
@@ -943,6 +948,100 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     assert.match(String(postResponse.headers.get('x-hosted-auth-duration-ms')), /^\d+$/);
     assert.match(String(postResponse.headers.get('x-hosted-auth-approval-duration-ms')), /^\d+$/);
     assert.match(String(postResponse.headers.get('set-cookie')), /clauth_approve=;/);
+    assert.equal(completionCount, 1);
+
+    completionCount = 0;
+    const returnToParam = new URL(approvalUrl).searchParams.get('return_to');
+    assert.ok(returnToParam);
+    const postWithoutApprovalCookie = await handleWorkerAuthHandoffRoutes({
+      request: new Request('https://worker.example/oauth/approve', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: `clmcp_ui=signed-session; ${flowCookie}; clmcp_csrf=csrf-token-123`,
+        },
+        body: `csrf_token=csrf-token-123&return_to=${encodeURIComponent(returnToParam)}`,
+      }),
+      url: new URL('https://worker.example/oauth/approve'),
+      env: {
+        OIDC_ISSUER: 'https://issuer.example',
+        OIDC_AUDIENCE: 'https://worker.example',
+        MCP_AUTH_OIDC_CLIENT_ID: 'oidc-client-id',
+        MCP_AUTH_OIDC_CLIENT_SECRET: 'oidc-client-secret',
+        MCP_UI_SESSION_SECRET: 'abcdefghijklmnopqrstuvwxyz123456',
+      },
+      deps: {
+        jsonError,
+        generateCspNonce: () => 'nonce',
+        htmlResponse,
+        workerUiSessionRuntime: {
+          getUiSessionSecret: () => 'abcdefghijklmnopqrstuvwxyz123456',
+          resolveUiSession: async () => ({ kind: 'authenticated', userId: 'user-123' }),
+          createUiSessionState: async () => null,
+          getOrCreateCsrfCookieHeader: () => null,
+          isSecureCookieRequest: () => true,
+        },
+        getOAuthHelpers: () => ({
+          parseAuthRequest: async () => ({ scope: ['legal:read'] }),
+          completeAuthorization: async () => {
+            completionCount += 1;
+            return { redirectTo: 'https://chatgpt.com/callback?code=worker-code&state=state-1' };
+          },
+        }),
+        buildHostedOAuthCompletionDetails: () => ({ metadata: {}, props: {} }),
+        resolveGrantedScopes: () => ['legal:read'],
+      },
+    });
+
+    assert.equal(postWithoutApprovalCookie.status, 302);
+    assert.equal(
+      postWithoutApprovalCookie.headers.get('location'),
+      'https://chatgpt.com/callback?code=worker-code&state=state-1',
+    );
+    assert.equal(completionCount, 1);
+
+    completionCount = 0;
+    const postWithFlowCookieOnly = await handleWorkerAuthHandoffRoutes({
+      request: new Request('https://worker.example/oauth/approve', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          cookie: `clmcp_ui=signed-session; ${flowCookie}; clmcp_csrf=csrf-token-123`,
+        },
+        body: 'csrf_token=csrf-token-123',
+      }),
+      url: new URL('https://worker.example/oauth/approve'),
+      env: {
+        OIDC_ISSUER: 'https://issuer.example',
+        OIDC_AUDIENCE: 'https://worker.example',
+        MCP_AUTH_OIDC_CLIENT_ID: 'oidc-client-id',
+        MCP_AUTH_OIDC_CLIENT_SECRET: 'oidc-client-secret',
+        MCP_UI_SESSION_SECRET: 'abcdefghijklmnopqrstuvwxyz123456',
+      },
+      deps: {
+        jsonError,
+        generateCspNonce: () => 'nonce',
+        htmlResponse,
+        workerUiSessionRuntime: {
+          getUiSessionSecret: () => 'abcdefghijklmnopqrstuvwxyz123456',
+          resolveUiSession: async () => ({ kind: 'authenticated', userId: 'user-123' }),
+          createUiSessionState: async () => null,
+          getOrCreateCsrfCookieHeader: () => null,
+          isSecureCookieRequest: () => true,
+        },
+        getOAuthHelpers: () => ({
+          parseAuthRequest: async () => ({ scope: ['legal:read'] }),
+          completeAuthorization: async () => {
+            completionCount += 1;
+            return { redirectTo: 'https://chatgpt.com/callback?code=worker-code&state=state-1' };
+          },
+        }),
+        buildHostedOAuthCompletionDetails: () => ({ metadata: {}, props: {} }),
+        resolveGrantedScopes: () => ['legal:read'],
+      },
+    });
+
+    assert.equal(postWithFlowCookieOnly.status, 302);
     assert.equal(completionCount, 1);
   });
 


### PR DESCRIPTION
## Summary
- promote the merged OAuth approval `return_to` fix from dev into main
- include the new browser regression for approval completion with posted `return_to`

## Validation
- PR #1568 merged into dev after required checks passed
- promotion branch built from origin/main with origin/dev changes squashed in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted OAuth approval handling (CSRF, cookies, and redirect targets), so mistakes could break sign-in or weaken return-target validation, though changes are scoped and well-tested.
> 
> **Overview**
> Fixes hosted OAuth approval completion when the `clauth_approve` cookie is missing by **posting and validating `return_to`** from the approval form and falling back to a persisted `clauth_flow` `returnTo` value.
> 
> Updates correlation/flow cookie handling to optionally persist `returnTo`, adds stricter validation for `return_to` mismatches, and changes the approval cookie `SameSite` to `Lax` (including consistent expiry). Adds unit + Playwright regression coverage for completing approval without the approval cookie and for the new form/action markup expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac74fb8b6607897c296c49ed44c66982b051ef1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->