### PR TITLE
chore: promote dev to main

### DIFF
--- a/.github/workflows/e2e-auth-chat-flow.yml
+++ b/.github/workflows/e2e-auth-chat-flow.yml
@@ -19,6 +19,7 @@ jobs:
 
     env:
       OAUTH_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+      OAUTH_CLIENT_ID: ${{ secrets.E2E_OAUTH_CLIENT_ID }}
 
     steps:
       - name: Checkout repository
@@ -49,3 +50,6 @@ jobs:
 
       - name: Run hosted OAuth handshake probe
         run: pnpm run test:e2e:oauth-remote
+
+      - name: Run OAuth approve contract probe
+        run: pnpm run test:e2e:oauth-approve-contract

--- a/docs/testing/E2E_AUTH_CHAT_FLOW.md
+++ b/docs/testing/E2E_AUTH_CHAT_FLOW.md
@@ -22,6 +22,10 @@ pnpm run test:e2e:oauth-remote
 - `OAUTH_CLIENT_ORIGIN` client origin used for DCR and metadata checks
 - `OAUTH_REDIRECT_URI` redirect URI used for the OAuth authorization request
 - `OAUTH_SCOPE` scope requested during the authorization probe
+- `OAUTH_CLIENT_ID` or `E2E_OAUTH_CLIENT_ID` skip dynamic registration when
+  CI/WAF blocks DCR
+- `OAUTH_REGISTRATION_RETRIES` retries transient registration failures like
+  `403`/`429`/`5xx` (default `3`)
 
 ## Notes
 
@@ -41,3 +45,5 @@ deployment monitor instead of a `push` gate for `main`.
 Configure these repository secrets:
 
 - `E2E_BASE_URL`
+- `E2E_OAUTH_CLIENT_ID` (optional) long-lived probe client when GitHub Actions
+  IPs cannot register

--- a/scripts/testing/e2e-remote-oauth-handshake.mjs
+++ b/scripts/testing/e2e-remote-oauth-handshake.mjs
@@ -14,11 +14,18 @@
  *   OAUTH_CLIENT_ORIGIN            Defaults to https://chatgpt.com
  *   OAUTH_REDIRECT_URI             Defaults to https://oauth-debug.example/callback
  *   OAUTH_SCOPE                    Defaults to legal:read legal:search legal:analyze
+ *   OAUTH_CLIENT_ID                Skip dynamic registration (also E2E_OAUTH_CLIENT_ID)
+ *   OAUTH_REGISTRATION_RETRIES     Retries for flaky DCR (default 3)
  */
 
 import crypto from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import { normalizeRemoteEndpoints } from '../resolve-remote-endpoints.js';
+
+export const OAUTH_PROBE_USER_AGENT = 'courtlistener-mcp-oauth-probe/1.0';
+
+const DEFAULT_REGISTRATION_RETRIES = 3;
+const REGISTRATION_RETRY_STATUSES = new Set([403, 429, 502, 503, 504]);
 
 export function resolveProbeConfig(env = process.env) {
   const baseUrlInput = env.OAUTH_BASE_URL?.trim() || env.REMOTE_SERVER_URL?.trim() || '';
@@ -29,12 +36,104 @@ export function resolveProbeConfig(env = process.env) {
     };
   }
 
+  const clientId = env.OAUTH_CLIENT_ID?.trim() || env.E2E_OAUTH_CLIENT_ID?.trim() || '';
+  const registrationRetries = Number.parseInt(env.OAUTH_REGISTRATION_RETRIES?.trim() || '', 10);
+
   return {
     baseUrl: normalizeRemoteEndpoints(baseUrlInput).baseUrl.replace(/\/+$/, ''),
     clientOrigin: (env.OAUTH_CLIENT_ORIGIN || 'https://chatgpt.com').trim(),
     redirectUri: (env.OAUTH_REDIRECT_URI || 'https://oauth-debug.example/callback').trim(),
     scope: (env.OAUTH_SCOPE || 'legal:read legal:search legal:analyze').trim(),
+    ...(clientId ? { clientId } : {}),
+    registrationRetries:
+      Number.isFinite(registrationRetries) && registrationRetries > 0
+        ? registrationRetries
+        : DEFAULT_REGISTRATION_RETRIES,
   };
+}
+
+export function registrationRetryDelayMs(attemptIndex) {
+  return 1000 * 2 ** attemptIndex;
+}
+
+export async function registerOAuthClient(
+  registrationEndpoint,
+  {
+    clientOrigin,
+    redirectUri,
+    scope,
+    clientName = 'Remote OAuth Probe',
+    retries = DEFAULT_REGISTRATION_RETRIES,
+    fetchImpl = fetch,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  },
+) {
+  const payload = {
+    client_name: clientName,
+    redirect_uris: [redirectUri],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+    scope,
+  };
+
+  let lastFailure = null;
+  for (let attempt = 0; attempt < retries; attempt += 1) {
+    const response = await fetchJson(
+      registrationEndpoint,
+      {
+        method: 'POST',
+        headers: {
+          Origin: clientOrigin,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      },
+      fetchImpl,
+    );
+
+    if (response.status === 201) {
+      assert(
+        typeof response.body?.client_id === 'string' && response.body.client_id.length > 0,
+        'Missing client_id',
+      );
+      assert(response.headers.get('location'), 'Missing registration Location header');
+      return response.body;
+    }
+
+    lastFailure = summarizeRegistrationFailure(response);
+    if (attempt < retries - 1 && REGISTRATION_RETRY_STATUSES.has(response.status)) {
+      await sleep(registrationRetryDelayMs(attempt));
+      continue;
+    }
+    break;
+  }
+
+  throw new Error(
+    `Expected 201, got ${lastFailure?.status ?? 'unknown'}${formatRegistrationFailureDetail(lastFailure)}`,
+  );
+}
+
+function summarizeRegistrationFailure(response) {
+  const bodySnippet =
+    typeof response.body === 'object' && response.body !== null
+      ? JSON.stringify(response.body).slice(0, 240)
+      : String(response.body ?? '').slice(0, 240);
+  return {
+    status: response.status,
+    bodySnippet,
+    cfRay: response.headers.get('cf-ray'),
+    retryAfter: response.headers.get('retry-after'),
+  };
+}
+
+function formatRegistrationFailureDetail(failure) {
+  if (!failure) return '';
+  const parts = [];
+  if (failure.bodySnippet) parts.push(` body=${failure.bodySnippet}`);
+  if (failure.cfRay) parts.push(` cf-ray=${failure.cfRay}`);
+  if (failure.retryAfter) parts.push(` retry-after=${failure.retryAfter}`);
+  return parts.length > 0 ? `;${parts.join(';')}` : '';
 }
 
 export async function main() {
@@ -70,30 +169,20 @@ export async function main() {
     );
   });
 
-  const registration = await step('Register public OAuth client', async () => {
-    const response = await fetchJson(discovery.registration_endpoint, {
-      method: 'POST',
-      headers: {
-        Origin: cfg.clientOrigin,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        client_name: 'Remote OAuth Probe',
-        redirect_uris: [cfg.redirectUri],
-        grant_types: ['authorization_code', 'refresh_token'],
-        response_types: ['code'],
-        token_endpoint_auth_method: 'none',
+  const registration = await step(
+    cfg.clientId ? 'Use configured OAuth client' : 'Register public OAuth client',
+    async () => {
+      if (cfg.clientId) {
+        return { client_id: cfg.clientId };
+      }
+      return registerOAuthClient(discovery.registration_endpoint, {
+        clientOrigin: cfg.clientOrigin,
+        redirectUri: cfg.redirectUri,
         scope: cfg.scope,
-      }),
-    });
-    assert(response.status === 201, `Expected 201, got ${response.status}`);
-    assert(
-      typeof response.body?.client_id === 'string' && response.body.client_id.length > 0,
-      'Missing client_id',
-    );
-    assert(response.headers.get('location'), 'Missing registration Location header');
-    return response.body;
-  });
+        retries: cfg.registrationRetries,
+      });
+    },
+  );
 
   const pkce = createPkce();
   const state = randomId('state');
@@ -166,8 +255,12 @@ function base64Url(buffer) {
   return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
-async function fetchJson(url, init = {}) {
-  const response = await fetch(url, init);
+async function fetchJson(url, init = {}, fetchImpl = fetch) {
+  const headers = new Headers(init.headers || {});
+  if (!headers.has('user-agent')) {
+    headers.set('user-agent', OAUTH_PROBE_USER_AGENT);
+  }
+  const response = await fetchImpl(url, { ...init, headers });
   const body = await response.json().catch(() => ({}));
   return { status: response.status, headers: response.headers, body };
 }

--- a/scripts/testing/probe-production-approve-contract.mjs
+++ b/scripts/testing/probe-production-approve-contract.mjs
@@ -6,33 +6,46 @@
  * redirects to sign-in instead of returning invalid_approval_state JSON.
  */
 
-const baseUrl = (process.env.OAUTH_BASE_URL || 'https://courtlistenermcp.blakeoxford.com').replace(
-  /\/+$/,
-  '',
-);
+import {
+  OAUTH_PROBE_USER_AGENT,
+  registerOAuthClient,
+  resolveProbeConfig,
+} from './e2e-remote-oauth-handshake.mjs';
+
+const DEFAULT_BASE_URL = 'https://courtlistenermcp.blakeoxford.com';
 
 async function main() {
-  const discovery = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`).then((r) =>
-    r.json(),
-  );
-  const registration = await fetch(discovery.registration_endpoint, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      client_name: 'Approve Contract Probe',
-      redirect_uris: ['http://127.0.0.1:59999/callback'],
-      grant_types: ['authorization_code'],
-      response_types: ['code'],
-      token_endpoint_auth_method: 'none',
-      scope: 'legal:read legal:search legal:analyze',
-    }),
+  const cfg = resolveProbeConfig({
+    ...process.env,
+    OAUTH_BASE_URL:
+      process.env.OAUTH_BASE_URL?.trim() ||
+      process.env.REMOTE_SERVER_URL?.trim() ||
+      DEFAULT_BASE_URL,
+  });
+
+  const baseUrl = cfg.baseUrl;
+  const redirectUri = 'http://127.0.0.1:59999/callback';
+  const scope = 'legal:read legal:search legal:analyze';
+
+  const discovery = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`, {
+    headers: { 'user-agent': OAUTH_PROBE_USER_AGENT },
   }).then((r) => r.json());
+
+  const registration = cfg.clientId
+    ? { client_id: cfg.clientId }
+    : await registerOAuthClient(discovery.registration_endpoint, {
+        clientOrigin: cfg.clientOrigin,
+        redirectUri,
+        scope,
+        clientName: 'Approve Contract Probe',
+        retries: cfg.registrationRetries,
+      });
 
   const authorizeUrl = new URL(discovery.authorization_endpoint);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', registration.client_id);
-  authorizeUrl.searchParams.set('redirect_uri', 'http://127.0.0.1:59999/callback');
-  authorizeUrl.searchParams.set('scope', 'legal:read legal:search legal:analyze');
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizeUrl.searchParams.set('scope', scope);
   authorizeUrl.searchParams.set('state', 'probe-state');
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('code_challenge', 'probe-challenge-not-s256-valid');

--- a/test/unit/test-remote-oauth-handshake.ts
+++ b/test/unit/test-remote-oauth-handshake.ts
@@ -5,10 +5,62 @@ import {
   assertAuthPortalHandoffContent,
   assertHostedAuthReadinessContract,
   probeHostedAuthReadiness,
+  registerOAuthClient,
+  registrationRetryDelayMs,
+  resolveProbeConfig,
   summarizeHostedAuthProbeResponse,
 } from '../../scripts/testing/e2e-remote-oauth-handshake.mjs';
 
 describe('remote oauth handshake probe', () => {
+  it('resolves a preconfigured client id for CI probes', () => {
+    const cfg = resolveProbeConfig({
+      OAUTH_BASE_URL: 'https://worker.example',
+      E2E_OAUTH_CLIENT_ID: 'probe-client-1',
+      OAUTH_REGISTRATION_RETRIES: '5',
+    });
+    assert.ok(!('skipReason' in cfg));
+    assert.equal(cfg.clientId, 'probe-client-1');
+    assert.equal(cfg.registrationRetries, 5);
+  });
+
+  it('retries transient registration failures before succeeding', async () => {
+    const attempts: number[] = [];
+    const registration = await registerOAuthClient('https://worker.example/register', {
+      clientOrigin: 'https://chatgpt.com',
+      redirectUri: 'https://oauth-debug.example/callback',
+      scope: 'legal:read',
+      retries: 3,
+      sleep: async () => {},
+      fetchImpl: async () => {
+        attempts.push(attempts.length + 1);
+        if (attempts.length < 3) {
+          return new Response('Forbidden', { status: 403 });
+        }
+        return new Response(
+          JSON.stringify({
+            client_id: 'client-registered',
+          }),
+          {
+            status: 201,
+            headers: {
+              'content-type': 'application/json',
+              location: 'https://worker.example/register/client-registered',
+            },
+          },
+        );
+      },
+    });
+
+    assert.equal(registration.client_id, 'client-registered');
+    assert.equal(attempts.length, 3);
+  });
+
+  it('uses exponential backoff between registration retries', () => {
+    assert.equal(registrationRetryDelayMs(0), 1000);
+    assert.equal(registrationRetryDelayMs(1), 2000);
+    assert.equal(registrationRetryDelayMs(2), 4000);
+  });
+
   it('probes the hosted-auth readiness redirect contract', async () => {
     let requestedUrl: string | null = null;
     const probe = await probeHostedAuthReadiness(


### PR DESCRIPTION
## Summary
- promote the merged scheduled OAuth probe resilience fix from `dev` to `main`
- carry the workflow, probe script, unit-test, and docs updates together as one promotion

## Validation
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run build
- npm run test:unit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow, test/probe scripts, and documentation, with no production runtime behavior impacted.
> 
> **Overview**
> Improves the scheduled hosted OAuth E2E monitoring by **allowing a preconfigured client id** (via `OAUTH_CLIENT_ID`/`E2E_OAUTH_CLIENT_ID`) and **adding retry + exponential backoff** around dynamic client registration to handle transient WAF/edge failures.
> 
> Refactors the approve-page contract probe to reuse the shared probe config/registration helpers and adds a consistent `user-agent` header for probe requests. The GitHub Actions workflow now passes the optional client id secret and runs the new `test:e2e:oauth-approve-contract` step; docs and unit tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26a2d727b73d4718fbb80c7b47f2f416cbbf8ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->