### PR TITLE
fix(testing): restore approve probe default base URL

### DIFF
--- a/docs/testing/E2E_AUTH_CHAT_FLOW.md
+++ b/docs/testing/E2E_AUTH_CHAT_FLOW.md
@@ -24,8 +24,8 @@ pnpm run test:e2e:oauth-remote
 - `OAUTH_SCOPE` scope requested during the authorization probe
 - `OAUTH_CLIENT_ID` or `E2E_OAUTH_CLIENT_ID` skip dynamic registration when
   CI/WAF blocks DCR
-- `OAUTH_REGISTRATION_RETRIES` retries for transient `403`/`429` on registration
-  (default `3`)
+- `OAUTH_REGISTRATION_RETRIES` retries transient registration failures with
+  `403`, `429`, `502`, `503`, or `504` responses (default `3`)
 
 ## Notes
 

--- a/scripts/testing/probe-production-approve-contract.mjs
+++ b/scripts/testing/probe-production-approve-contract.mjs
@@ -12,11 +12,16 @@ import {
   resolveProbeConfig,
 } from './e2e-remote-oauth-handshake.mjs';
 
+const DEFAULT_BASE_URL = 'https://courtlistenermcp.blakeoxford.com';
+
 async function main() {
-  const cfg = resolveProbeConfig();
-  if ('skipReason' in cfg) {
-    throw new Error(cfg.skipReason);
-  }
+  const cfg = resolveProbeConfig({
+    ...process.env,
+    OAUTH_BASE_URL:
+      process.env.OAUTH_BASE_URL?.trim() ||
+      process.env.REMOTE_SERVER_URL?.trim() ||
+      DEFAULT_BASE_URL,
+  });
 
   const baseUrl = cfg.baseUrl;
   const redirectUri = 'http://127.0.0.1:59999/callback';


### PR DESCRIPTION
## Summary
- restore the approve-contract probe's default production base URL while keeping env overrides
- align the hosted OAuth probe docs with the actual 403/429/5xx retry policy

## Validation
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run build
- npm run test:unit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect test/probe scripts and documentation, with no production runtime logic impacted.
> 
> **Overview**
> Restores `probe-production-approve-contract.mjs` to run against a default production `OAUTH_BASE_URL` (`https://courtlistenermcp.blakeoxford.com`) when neither `OAUTH_BASE_URL` nor `REMOTE_SERVER_URL` is set, while still allowing env overrides.
> 
> Updates `E2E_AUTH_CHAT_FLOW.md` to clarify that `OAUTH_REGISTRATION_RETRIES` covers transient DCR failures including `403`/`429`/*`5xx`* statuses (default `3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48d87cc5198c2271e50de68d2f047994abac6f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->