### PR TITLE
chore: GitHub cleanup — cancellation fix and E2E target validation

### DIFF
--- a/.github/workflows/e2e-auth-chat-flow.yml
+++ b/.github/workflows/e2e-auth-chat-flow.yml
@@ -47,6 +47,10 @@ jobs:
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
+          echo "E2E target host: $(node -e "console.log(new URL(process.env.OAUTH_BASE_URL).host)")"
+
+      - name: Validate E2E OAuth target exposes hosted-auth readiness
+        run: pnpm run test:e2e:oauth-target
 
       - name: Run hosted OAuth handshake probe
         run: pnpm run test:e2e:oauth-remote

--- a/docs/testing/E2E_AUTH_CHAT_FLOW.md
+++ b/docs/testing/E2E_AUTH_CHAT_FLOW.md
@@ -44,6 +44,8 @@ deployment monitor instead of a `push` gate for `main`.
 
 Configure these repository secrets:
 
-- `E2E_BASE_URL`
+- `E2E_BASE_URL` — must be the production custom domain (recommended:
+  `https://courtlistenermcp.blakeoxford.com`). `*.workers.dev` aliases return
+  `404` on `/auth/start` and will fail the readiness contract.
 - `E2E_OAUTH_CLIENT_ID` (optional) long-lived probe client when GitHub Actions
   IPs cannot register

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "mcp:test:remote": "node scripts/dev/test-remote-mcp.js",
     "test:e2e:ai-chat-presets": "node scripts/testing/e2e-ai-chat-presets.mjs",
     "test:e2e:oauth-remote": "node scripts/testing/e2e-remote-oauth-handshake.mjs",
+    "test:e2e:oauth-target": "node scripts/testing/validate-e2e-oauth-target.mjs",
     "test:e2e:oauth-approve-contract": "node scripts/testing/probe-production-approve-contract.mjs",
     "test:e2e:worker-auth-flow": "node scripts/testing/e2e-remote-oauth-handshake.mjs",
     "dev": "tsc --watch --preserveWatchOutput",

--- a/scripts/testing/validate-e2e-oauth-target.mjs
+++ b/scripts/testing/validate-e2e-oauth-target.mjs
@@ -15,13 +15,13 @@ import {
 
 const RECOMMENDED_BASE_URL = 'https://courtlistenermcp.blakeoxford.com';
 
-export async function validateE2eOAuthTarget(env = process.env) {
+export async function validateE2eOAuthTarget(env = process.env, fetchImpl = fetch) {
   const cfg = resolveProbeConfig(env);
   if ('skipReason' in cfg) {
     throw new Error(cfg.skipReason);
   }
 
-  const probe = await probeHostedAuthReadiness(cfg.baseUrl);
+  const probe = await probeHostedAuthReadiness(cfg.baseUrl, null, fetchImpl);
   try {
     assertHostedAuthReadinessContract(probe);
   } catch (error) {

--- a/scripts/testing/validate-e2e-oauth-target.mjs
+++ b/scripts/testing/validate-e2e-oauth-target.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that E2E_BASE_URL points at a Worker deployment that exposes the
+ * hosted-auth readiness contract used by scheduled OAuth monitors.
+ */
+
+import { pathToFileURL } from 'node:url';
+import {
+  OAUTH_PROBE_USER_AGENT,
+  assertHostedAuthReadinessContract,
+  probeHostedAuthReadiness,
+  resolveProbeConfig,
+} from './e2e-remote-oauth-handshake.mjs';
+
+const RECOMMENDED_BASE_URL = 'https://courtlistenermcp.blakeoxford.com';
+
+export async function validateE2eOAuthTarget(env = process.env) {
+  const cfg = resolveProbeConfig(env);
+  if ('skipReason' in cfg) {
+    throw new Error(cfg.skipReason);
+  }
+
+  const probe = await probeHostedAuthReadiness(cfg.baseUrl);
+  try {
+    assertHostedAuthReadinessContract(probe);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      [
+        `E2E OAuth target failed hosted-auth readiness validation for ${cfg.baseUrl}.`,
+        message,
+        `Update repository secret E2E_BASE_URL to the production custom domain (recommended: ${RECOMMENDED_BASE_URL}).`,
+        'workers.dev aliases and stale deployments do not expose /auth/start with X-Hosted-Auth-* headers.',
+      ].join(' '),
+    );
+  }
+
+  return {
+    ok: true,
+    baseUrl: cfg.baseUrl,
+    recommendedBaseUrl: RECOMMENDED_BASE_URL,
+    probe,
+  };
+}
+
+async function main() {
+  const result = await validateE2eOAuthTarget();
+  console.log(
+    JSON.stringify(
+      {
+        ok: result.ok,
+        baseUrl: result.baseUrl,
+        hostedAuthRoute: result.probe.hostedAuthRoute,
+        hostedAuthStatus: result.probe.hostedAuthStatus,
+        userAgent: OAUTH_PROBE_USER_AGENT,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/src/server/worker-async-queue-runtime.ts
+++ b/src/server/worker-async-queue-runtime.ts
@@ -335,7 +335,9 @@ export async function processAsyncQueueMessage(params: {
           job.userId,
         ),
     );
-    if (job.cancellationRequested) {
+    // Re-read job from KV to check if cancellation was requested during execution
+    const freshJob = await readJob(params.env, params.message.jobId);
+    if (freshJob?.cancellationRequested) {
       throw new Error('Job cancelled during execution');
     }
     if (result.isError) {
@@ -348,9 +350,13 @@ export async function processAsyncQueueMessage(params: {
     await writeJob(params.env, job);
     params.onAsyncJobUpdate?.('succeeded', job.toolName, job.attempts.current);
   } catch (error) {
+    // Re-read job from KV to get fresh cancellation state for retry/error decisions
+    const freshJobState = await readJob(params.env, params.message.jobId);
+    const cancellationRequested = freshJobState?.cancellationRequested ?? false;
+
     const message = error instanceof Error ? error.message : String(error);
     const history = [...(job.error?.history ?? []), message];
-    if (job.attempts.current < job.attempts.max && !job.cancellationRequested) {
+    if (job.attempts.current < job.attempts.max && !cancellationRequested) {
       job.status = 'queued';
       job.updatedAtMs = Date.now();
       job.queuedAtMs = job.updatedAtMs;
@@ -374,9 +380,9 @@ export async function processAsyncQueueMessage(params: {
     job.status = 'failed';
     job.updatedAtMs = Date.now();
     job.error = {
-      code: job.cancellationRequested ? 'cancelled' : 'max_attempts_exceeded',
+      code: cancellationRequested ? 'cancelled' : 'max_attempts_exceeded',
       message,
-      deadLetter: !job.cancellationRequested,
+      deadLetter: !cancellationRequested,
       attempts: job.attempts.current,
       history,
     };

--- a/src/server/worker-async-queue-runtime.ts
+++ b/src/server/worker-async-queue-runtime.ts
@@ -353,6 +353,7 @@ export async function processAsyncQueueMessage(params: {
     // Re-read job from KV to get fresh cancellation state for retry/error decisions
     const freshJobState = await readJob(params.env, params.message.jobId);
     const cancellationRequested = freshJobState?.cancellationRequested ?? false;
+    job.cancellationRequested = cancellationRequested;
 
     const message = error instanceof Error ? error.message : String(error);
     const history = [...(job.error?.history ?? []), message];

--- a/test/unit/test-remote-oauth-handshake.ts
+++ b/test/unit/test-remote-oauth-handshake.ts
@@ -10,8 +10,16 @@ import {
   resolveProbeConfig,
   summarizeHostedAuthProbeResponse,
 } from '../../scripts/testing/e2e-remote-oauth-handshake.mjs';
+import { validateE2eOAuthTarget } from '../../scripts/testing/validate-e2e-oauth-target.mjs';
 
 describe('remote oauth handshake probe', () => {
+  it('validates the production E2E OAuth target contract', async () => {
+    const result = await validateE2eOAuthTarget({
+      OAUTH_BASE_URL: 'https://courtlistenermcp.blakeoxford.com',
+    });
+    assert.equal(result.probe.hostedAuthRoute, 'auth-start');
+  });
+
   it('resolves a preconfigured client id for CI probes', () => {
     const cfg = resolveProbeConfig({
       OAUTH_BASE_URL: 'https://worker.example',

--- a/test/unit/test-remote-oauth-handshake.ts
+++ b/test/unit/test-remote-oauth-handshake.ts
@@ -13,11 +13,38 @@ import {
 import { validateE2eOAuthTarget } from '../../scripts/testing/validate-e2e-oauth-target.mjs';
 
 describe('remote oauth handshake probe', () => {
-  it('validates the production E2E OAuth target contract', async () => {
-    const result = await validateE2eOAuthTarget({
-      OAUTH_BASE_URL: 'https://courtlistenermcp.blakeoxford.com',
-    });
+  it('validates E2E OAuth targets that expose hosted-auth readiness headers', async () => {
+    const result = await validateE2eOAuthTarget(
+      { OAUTH_BASE_URL: 'https://worker.example' },
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: 'https://issuer.example/authorize',
+            'x-hosted-auth-ready': 'true',
+            'x-hosted-auth-status': 'ready',
+            'x-hosted-auth-route': 'auth-start',
+            'x-hosted-auth-outcome': 'redirect',
+            'x-hosted-auth-category': 'ok',
+            'x-hosted-auth-correlation-id': 'corr_e2e_target',
+            'x-hosted-auth-config-error-count': '0',
+            'x-hosted-auth-duration-ms': '5',
+            'x-hosted-auth-upstream-discovery-duration-ms': '2',
+          },
+        }),
+    );
     assert.equal(result.probe.hostedAuthRoute, 'auth-start');
+  });
+
+  it('rejects E2E OAuth targets without hosted-auth readiness headers', async () => {
+    await assert.rejects(
+      () =>
+        validateE2eOAuthTarget(
+          { OAUTH_BASE_URL: 'https://courtlistener-mcp.blakeoxford.workers.dev' },
+          async () => new Response('Not Found', { status: 404 }),
+        ),
+      /E2E OAuth target failed hosted-auth readiness validation/,
+    );
   });
 
   it('resolves a preconfigured client id for CI probes', () => {


### PR DESCRIPTION
## Summary

- **Async queue:** Re-read job from KV after execution so mid-flight cancellation is detected (restores orphaned `fix/cancellation-check-after-execution` work).
- **Scheduled OAuth CI:** Add `validate-e2e-oauth-target` and workflow step; documents that `E2E_BASE_URL` must be the production custom domain (`courtlistenermcp.blakeoxford.com`), not `*.workers.dev`.
- Repository secret `E2E_BASE_URL` updated to the production custom domain.

## Test plan

- [x] `npx tsx --test test/unit/test-remote-oauth-handshake.ts`
- [x] `OAUTH_BASE_URL=https://courtlistenermcp.blakeoxford.com pnpm run test:e2e:oauth-target`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async job execution/retry logic by re-reading cancellation state from KV, which could affect job outcome and dead-lettering behavior if incorrect. The rest is CI/testing validation for remote OAuth monitoring and is low-impact to runtime.
> 
> **Overview**
> **Improves scheduled hosted-OAuth monitoring** by adding a new `test:e2e:oauth-target` validation step (and script) that fails fast when `E2E_BASE_URL` doesn’t expose the expected hosted-auth readiness headers (with docs clarifying the required production custom domain vs `*.workers.dev`).
> 
> **Fixes async queue cancellation handling** by re-reading job state from KV after execution and during error handling so cancellations requested mid-flight prevent retries and are reported as `cancelled` instead of being dead-lettered as normal failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc8ca32f741d7bbb2b3aa02bc3b884c672262db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->