### PR TITLE
chore: promote dev to main

### DIFF
--- a/test/unit/test-worker-async-queue-runtime.ts
+++ b/test/unit/test-worker-async-queue-runtime.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import {
+  processAsyncQueueMessage,
+  type AsyncJobMessage,
+} from '../../src/server/worker-async-queue-runtime.js';
+
+class SilentLogger {
+  info(): void {}
+  debug(): void {}
+  warn(): void {}
+  error(): void {}
+  child(): SilentLogger {
+    return this;
+  }
+  startTimer(): { end(): number; endWithError(): number } {
+    return { end: () => 0, endWithError: () => 0 };
+  }
+  toolExecution(): void {}
+  apiCall(): void {}
+}
+
+class MemoryKvNamespace {
+  private readonly store = new Map<string, string>();
+
+  async get(
+    key: string,
+    type?: 'text' | 'json' | 'arrayBuffer' | 'stream',
+  ): Promise<unknown | null> {
+    const value = this.store.get(key);
+    if (value === undefined) {
+      return null;
+    }
+    if (type === 'json') {
+      return JSON.parse(value) as unknown;
+    }
+    return value;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+}
+
+describe('processAsyncQueueMessage', () => {
+  it('preserves cancellationRequested when cancellation is persisted during execution', async () => {
+    const kv = new MemoryKvNamespace();
+    const message: AsyncJobMessage = { jobId: 'job-running-cancelled' };
+    const now = Date.now();
+    const request: CallToolRequest = {
+      method: 'tools/call',
+      params: {
+        name: 'delayed_flaky',
+        arguments: {},
+      },
+    };
+
+    await kv.put(
+      `job:${message.jobId}`,
+      JSON.stringify({
+        id: message.jobId,
+        toolName: request.params.name,
+        request,
+        requestId: 'request-1',
+        status: 'queued',
+        createdAtMs: now,
+        updatedAtMs: now,
+        expiresAtMs: now + 60_000,
+        attempts: {
+          current: 0,
+          max: 3,
+        },
+        retryDelayMs: 1,
+        cancellationRequested: false,
+        queuedAtMs: now,
+      }),
+    );
+
+    let sawRunningState = false;
+    const execute = async (): Promise<CallToolResult> => {
+      const runningJob = (await kv.get(`job:${message.jobId}`, 'json')) as Record<string, unknown>;
+      assert.equal(runningJob.status, 'running');
+      sawRunningState = true;
+      await kv.put(
+        `job:${message.jobId}`,
+        JSON.stringify({
+          ...runningJob,
+          cancellationRequested: true,
+        }),
+      );
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        isError: false,
+      };
+    };
+
+    await processAsyncQueueMessage({
+      env: {
+        ASYNC_JOBS_KV: kv as unknown as KVNamespace,
+        ASYNC_TOOL_QUEUE: {
+          send: async () => undefined,
+        } as unknown as Queue<AsyncJobMessage>,
+      },
+      logger: new SilentLogger() as never,
+      message,
+      execute,
+    });
+
+    const terminalJob = (await kv.get(`job:${message.jobId}`, 'json')) as Record<string, unknown>;
+    const error = terminalJob.error as Record<string, unknown>;
+
+    assert.equal(sawRunningState, true);
+    assert.equal(terminalJob.status, 'failed');
+    assert.equal(terminalJob.cancellationRequested, true);
+    assert.equal(error.code, 'cancelled');
+    assert.equal(error.deadLetter, false);
+  });
+});


### PR DESCRIPTION
## Summary
- promote the async cancellation-state fix from dev to main
- include the new queue-backed regression test for processAsyncQueueMessage

## Validation
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run build
- npm run test:unit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a unit test only, with no production logic changes. Risk is limited to potential test flakiness due to timing/state assumptions.
> 
> **Overview**
> Adds a new unit regression test (`test-worker-async-queue-runtime.ts`) that simulates a KV-backed async job being cancelled *while running* and asserts `processAsyncQueueMessage` re-reads KV state, marks the job as `failed` with `error.code = cancelled`, and preserves `cancellationRequested = true` (without dead-lettering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80c110c12c6fef72b25fe375d0259a054d5d5fa0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->