### PR TITLE
fix(testing): send probe User-Agent on all OAuth monitor fetches

### DIFF
--- a/scripts/testing/e2e-remote-oauth-handshake.mjs
+++ b/scripts/testing/e2e-remote-oauth-handshake.mjs
@@ -210,7 +210,7 @@ export async function main() {
   const authRedirect = await step(
     'Request /authorize and capture auth portal redirect',
     async () => {
-      const response = await fetch(authorizeUrl, { method: 'GET', redirect: 'manual' });
+      const response = await probeFetch(authorizeUrl, { method: 'GET', redirect: 'manual' });
       assert(isRedirect(response.status), `Expected redirect, got ${response.status}`);
       const location = response.headers.get('location');
       assert(location, 'Missing authorize redirect location');
@@ -228,7 +228,7 @@ export async function main() {
   );
 
   await step('Fetch auth portal handoff page', async () => {
-    const response = await fetch(authRedirect, { redirect: 'manual' });
+    const response = await probeFetch(authRedirect, { redirect: 'manual' });
     assert(
       isRedirect(response.status) || response.status === 200,
       `Expected redirect or 200, got ${response.status}`,
@@ -260,12 +260,23 @@ function base64Url(buffer) {
   return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
-async function fetchJson(url, init = {}, fetchImpl = fetch) {
+function withProbeHeaders(init = {}) {
   const headers = new Headers(init.headers || {});
   if (!headers.has('user-agent')) {
     headers.set('user-agent', OAUTH_PROBE_USER_AGENT);
   }
-  const response = await fetchImpl(url, { ...init, headers });
+  if (!headers.has('accept')) {
+    headers.set('accept', 'text/html,application/json');
+  }
+  return { ...init, headers };
+}
+
+export async function probeFetch(url, init = {}, fetchImpl = fetch) {
+  return fetchImpl(url, withProbeHeaders(init));
+}
+
+async function fetchJson(url, init = {}, fetchImpl = fetch) {
+  const response = await probeFetch(url, init, fetchImpl);
   const body = await response.json().catch(() => ({}));
   return { status: response.status, headers: response.headers, body };
 }
@@ -305,14 +316,14 @@ export async function probeHostedAuthReadiness(baseUrl, returnTo = null, fetchIm
     probeUrl.searchParams.set('return_to', returnTo.trim());
   }
 
-  const response = await fetchImpl(probeUrl, {
-    method: 'GET',
-    redirect: 'manual',
-    headers: {
-      'user-agent': OAUTH_PROBE_USER_AGENT,
-      accept: 'text/html,application/json',
+  const response = await probeFetch(
+    probeUrl,
+    {
+      method: 'GET',
+      redirect: 'manual',
     },
-  });
+    fetchImpl,
+  );
 
   return summarizeHostedAuthProbeResponse(response);
 }

--- a/scripts/testing/e2e-remote-oauth-handshake.mjs
+++ b/scripts/testing/e2e-remote-oauth-handshake.mjs
@@ -265,9 +265,6 @@ function withProbeHeaders(init = {}) {
   if (!headers.has('user-agent')) {
     headers.set('user-agent', OAUTH_PROBE_USER_AGENT);
   }
-  if (!headers.has('accept')) {
-    headers.set('accept', 'text/html,application/json');
-  }
   return { ...init, headers };
 }
 
@@ -325,6 +322,9 @@ export async function probeHostedAuthReadiness(baseUrl, returnTo = null, fetchIm
     {
       method: 'GET',
       redirect: 'manual',
+      headers: {
+        accept: 'text/html,application/json',
+      },
     },
     fetchImpl,
   );

--- a/scripts/testing/e2e-remote-oauth-handshake.mjs
+++ b/scripts/testing/e2e-remote-oauth-handshake.mjs
@@ -276,7 +276,11 @@ export async function probeFetch(url, init = {}, fetchImpl = fetch) {
 }
 
 async function fetchJson(url, init = {}, fetchImpl = fetch) {
-  const response = await probeFetch(url, init, fetchImpl);
+  const headers = new Headers(init.headers || {});
+  if (!headers.has('accept')) {
+    headers.set('accept', 'application/json');
+  }
+  const response = await probeFetch(url, { ...init, headers }, fetchImpl);
   const body = await response.json().catch(() => ({}));
   return { status: response.status, headers: response.headers, body };
 }

--- a/scripts/testing/probe-production-approve-contract.mjs
+++ b/scripts/testing/probe-production-approve-contract.mjs
@@ -27,9 +27,9 @@ async function main() {
   const redirectUri = 'http://127.0.0.1:59999/callback';
   const scope = 'legal:read legal:search legal:analyze';
 
-  const discovery = await probeFetch(`${baseUrl}/.well-known/oauth-authorization-server`).then(
-    (r) => r.json(),
-  );
+  const discovery = await probeFetch(`${baseUrl}/.well-known/oauth-authorization-server`, {
+    headers: { accept: 'application/json' },
+  }).then((r) => r.json());
 
   const registration = cfg.clientId
     ? { client_id: cfg.clientId }

--- a/scripts/testing/probe-production-approve-contract.mjs
+++ b/scripts/testing/probe-production-approve-contract.mjs
@@ -7,7 +7,7 @@
  */
 
 import {
-  OAUTH_PROBE_USER_AGENT,
+  probeFetch,
   registerOAuthClient,
   resolveProbeConfig,
 } from './e2e-remote-oauth-handshake.mjs';
@@ -27,9 +27,9 @@ async function main() {
   const redirectUri = 'http://127.0.0.1:59999/callback';
   const scope = 'legal:read legal:search legal:analyze';
 
-  const discovery = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`, {
-    headers: { 'user-agent': OAUTH_PROBE_USER_AGENT },
-  }).then((r) => r.json());
+  const discovery = await probeFetch(`${baseUrl}/.well-known/oauth-authorization-server`).then(
+    (r) => r.json(),
+  );
 
   const registration = cfg.clientId
     ? { client_id: cfg.clientId }
@@ -50,7 +50,7 @@ async function main() {
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('code_challenge', 'probe-challenge-not-s256-valid');
 
-  const authorizeRes = await fetch(authorizeUrl, { redirect: 'manual' });
+  const authorizeRes = await probeFetch(authorizeUrl, { redirect: 'manual' });
   const authStart = authorizeRes.headers.get('location');
   if (!authStart?.includes('/auth/start')) {
     throw new Error(`Expected /auth/start redirect, got ${authStart}`);
@@ -64,7 +64,7 @@ async function main() {
   const approveUrl = new URL('/oauth/approve', baseUrl);
   approveUrl.searchParams.set('return_to', returnTo);
 
-  const approveGet = await fetch(approveUrl, { redirect: 'manual' });
+  const approveGet = await probeFetch(approveUrl, { redirect: 'manual' });
   const approveGetLocation = approveGet.headers.get('location') || '';
   if (!approveGetLocation.includes('/auth/start')) {
     throw new Error(
@@ -72,7 +72,7 @@ async function main() {
     );
   }
 
-  const approvePost = await fetch(`${baseUrl}/oauth/approve`, {
+  const approvePost = await probeFetch(`${baseUrl}/oauth/approve`, {
     method: 'POST',
     redirect: 'manual',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
Fixes CI 403 on /oauth/authorize by applying the probe User-Agent to authorize and approve fetches, not only DCR/readiness.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test/probe scripts only, primarily header plumbing and small refactors around `fetch` usage.
> 
> **Overview**
> Ensures all OAuth monitoring/probe requests consistently send the probe headers by introducing `withProbeHeaders` + exported `probeFetch`, and routing `fetchJson`, `/oauth/authorize`, and `/auth/start` handoff fetches through it.
> 
> Updates the production approve-page contract probe to use `probeFetch` for discovery, authorize, and approve GET/POST requests so these endpoints are exercised with the same header contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd4e608216bd8e2c78f5e48bc774664ea0964bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->