### PR TITLE
chore: promote dev to main

### DIFF
--- a/scripts/testing/e2e-remote-oauth-handshake.mjs
+++ b/scripts/testing/e2e-remote-oauth-handshake.mjs
@@ -210,7 +210,7 @@ export async function main() {
   const authRedirect = await step(
     'Request /authorize and capture auth portal redirect',
     async () => {
-      const response = await fetch(authorizeUrl, { method: 'GET', redirect: 'manual' });
+      const response = await probeFetch(authorizeUrl, { method: 'GET', redirect: 'manual' });
       assert(isRedirect(response.status), `Expected redirect, got ${response.status}`);
       const location = response.headers.get('location');
       assert(location, 'Missing authorize redirect location');
@@ -228,7 +228,7 @@ export async function main() {
   );
 
   await step('Fetch auth portal handoff page', async () => {
-    const response = await fetch(authRedirect, { redirect: 'manual' });
+    const response = await probeFetch(authRedirect, { redirect: 'manual' });
     assert(
       isRedirect(response.status) || response.status === 200,
       `Expected redirect or 200, got ${response.status}`,
@@ -260,12 +260,24 @@ function base64Url(buffer) {
   return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
-async function fetchJson(url, init = {}, fetchImpl = fetch) {
+function withProbeHeaders(init = {}) {
   const headers = new Headers(init.headers || {});
   if (!headers.has('user-agent')) {
     headers.set('user-agent', OAUTH_PROBE_USER_AGENT);
   }
-  const response = await fetchImpl(url, { ...init, headers });
+  return { ...init, headers };
+}
+
+export async function probeFetch(url, init = {}, fetchImpl = fetch) {
+  return fetchImpl(url, withProbeHeaders(init));
+}
+
+async function fetchJson(url, init = {}, fetchImpl = fetch) {
+  const headers = new Headers(init.headers || {});
+  if (!headers.has('accept')) {
+    headers.set('accept', 'application/json');
+  }
+  const response = await probeFetch(url, { ...init, headers }, fetchImpl);
   const body = await response.json().catch(() => ({}));
   return { status: response.status, headers: response.headers, body };
 }
@@ -305,14 +317,17 @@ export async function probeHostedAuthReadiness(baseUrl, returnTo = null, fetchIm
     probeUrl.searchParams.set('return_to', returnTo.trim());
   }
 
-  const response = await fetchImpl(probeUrl, {
-    method: 'GET',
-    redirect: 'manual',
-    headers: {
-      'user-agent': OAUTH_PROBE_USER_AGENT,
-      accept: 'text/html,application/json',
+  const response = await probeFetch(
+    probeUrl,
+    {
+      method: 'GET',
+      redirect: 'manual',
+      headers: {
+        accept: 'text/html,application/json',
+      },
     },
-  });
+    fetchImpl,
+  );
 
   return summarizeHostedAuthProbeResponse(response);
 }

--- a/scripts/testing/probe-production-approve-contract.mjs
+++ b/scripts/testing/probe-production-approve-contract.mjs
@@ -7,7 +7,7 @@
  */
 
 import {
-  OAUTH_PROBE_USER_AGENT,
+  probeFetch,
   registerOAuthClient,
   resolveProbeConfig,
 } from './e2e-remote-oauth-handshake.mjs';
@@ -27,8 +27,8 @@ async function main() {
   const redirectUri = 'http://127.0.0.1:59999/callback';
   const scope = 'legal:read legal:search legal:analyze';
 
-  const discovery = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`, {
-    headers: { 'user-agent': OAUTH_PROBE_USER_AGENT },
+  const discovery = await probeFetch(`${baseUrl}/.well-known/oauth-authorization-server`, {
+    headers: { accept: 'application/json' },
   }).then((r) => r.json());
 
   const registration = cfg.clientId
@@ -50,7 +50,7 @@ async function main() {
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('code_challenge', 'probe-challenge-not-s256-valid');
 
-  const authorizeRes = await fetch(authorizeUrl, { redirect: 'manual' });
+  const authorizeRes = await probeFetch(authorizeUrl, { redirect: 'manual' });
   const authStart = authorizeRes.headers.get('location');
   if (!authStart?.includes('/auth/start')) {
     throw new Error(`Expected /auth/start redirect, got ${authStart}`);
@@ -64,7 +64,7 @@ async function main() {
   const approveUrl = new URL('/oauth/approve', baseUrl);
   approveUrl.searchParams.set('return_to', returnTo);
 
-  const approveGet = await fetch(approveUrl, { redirect: 'manual' });
+  const approveGet = await probeFetch(approveUrl, { redirect: 'manual' });
   const approveGetLocation = approveGet.headers.get('location') || '';
   if (!approveGetLocation.includes('/auth/start')) {
     throw new Error(
@@ -72,7 +72,7 @@ async function main() {
     );
   }
 
-  const approvePost = await fetch(`${baseUrl}/oauth/approve`, {
+  const approvePost = await probeFetch(`${baseUrl}/oauth/approve`, {
     method: 'POST',
     redirect: 'manual',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
Promotes OAuth probe fixes, async cancellation improvements, and E2E validation after #1585.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts async queue job failure handling to immediately mark deterministic tool errors as failed/dead-lettered, which changes retry behavior and persisted error payloads. OAuth probe changes are low risk but the worker runtime change could affect production async execution outcomes if `result.isError` is returned unexpectedly.
> 
> **Overview**
> Standardizes OAuth probe HTTP requests by introducing `probeFetch` (consistent `user-agent` + default `accept` headers) and switching the remote handshake + production approve-contract probes to use it; `fetchJson` now routes through `probeFetch` while forcing `accept: application/json`.
> 
> Updates async queue processing so a tool-returned error result (`result.isError`) is treated as a **deterministic failure**: the job is persisted as `failed` with the tool result + a synthesized message/history, marked `deadLetter: true`, and execution returns without entering the retry path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a1059af5ff6e662bf9421b244e401e225435b4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->