### PR TITLE
fix(cloudflare): allow oauth probe traffic through edge protections

### DIFF
--- a/infra/cloudflare/terraform/main.tf
+++ b/infra/cloudflare/terraform/main.tf
@@ -1,0 +1,32 @@
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+data "cloudflare_zone" "mcp" {
+  name = var.zone_name
+}
+
+resource "cloudflare_ruleset" "oauth_probe_skip" {
+  zone_id     = data.cloudflare_zone.mcp.id
+  name        = "Allow hosted OAuth probes"
+  description = "Skips bot/rate-limit edge checks for the hosted OAuth monitoring probe user-agent."
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  rules {
+    ref         = "allow_oauth_probe_monitoring"
+    description = "Allow hosted OAuth CI/probe traffic"
+    expression  = "(http.host eq \"${var.mcp_hostname}\" and http.user_agent contains \"courtlistener-mcp-oauth-probe\")"
+    action      = "skip"
+    enabled     = true
+
+    action_parameters {
+      phases   = ["http_request_sbfm", "http_ratelimit"]
+      products = ["bic", "uaBlock", "securityLevel"]
+    }
+
+    logging {
+      enabled = true
+    }
+  }
+}

--- a/infra/cloudflare/terraform/main.tf
+++ b/infra/cloudflare/terraform/main.tf
@@ -3,7 +3,9 @@ provider "cloudflare" {
 }
 
 data "cloudflare_zone" "mcp" {
-  name = var.zone_name
+  filter = {
+    name = var.zone_name
+  }
 }
 
 resource "cloudflare_ruleset" "oauth_probe_skip" {
@@ -13,20 +15,20 @@ resource "cloudflare_ruleset" "oauth_probe_skip" {
   kind        = "zone"
   phase       = "http_request_firewall_custom"
 
-  rules {
+  rules = [{
     ref         = "allow_oauth_probe_monitoring"
     description = "Allow hosted OAuth CI/probe traffic"
     expression  = "(http.host eq \"${var.mcp_hostname}\" and http.user_agent contains \"courtlistener-mcp-oauth-probe\")"
     action      = "skip"
     enabled     = true
 
-    action_parameters {
+    action_parameters = {
       phases   = ["http_request_sbfm", "http_ratelimit"]
       products = ["bic", "uaBlock", "securityLevel"]
     }
 
-    logging {
+    logging = {
       enabled = true
     }
-  }
+  }]
 }

--- a/infra/cloudflare/terraform/terraform.tfvars.example
+++ b/infra/cloudflare/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+cloudflare_api_token = "replace-with-zone-waf-edit-token"
+zone_name            = "blakeoxford.com"
+mcp_hostname         = "courtlistenermcp.blakeoxford.com"

--- a/infra/cloudflare/terraform/variables.tf
+++ b/infra/cloudflare/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "cloudflare_api_token" {
+  type        = string
+  description = "API token with Zone.Zone Read and Zone.WAF Edit."
+  sensitive   = true
+}
+
+variable "zone_name" {
+  type        = string
+  description = "Cloudflare zone that hosts the MCP custom domain."
+  default     = "blakeoxford.com"
+}
+
+variable "mcp_hostname" {
+  type        = string
+  description = "Worker custom domain hostname for hosted OAuth probes."
+  default     = "courtlistenermcp.blakeoxford.com"
+}

--- a/infra/cloudflare/terraform/versions.tf
+++ b/infra/cloudflare/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "cloudflare:deploy": "pnpm run cloudflare:check && wrangler deploy",
     "cloudflare:tail": "wrangler tail",
     "cloudflare:register:oauth": "node scripts/cloudflare/register-oauth-client.mjs",
+    "cloudflare:waf:ensure": "node scripts/cloudflare/ensure-waf-probe-access.mjs",
+    "cloudflare:zone:id": "node scripts/cloudflare/print-zone-id.mjs",
     "start": "node dist/index.js",
     "start:http": "node dist/http.js",
     "doctor": "node dist/index.js --doctor",

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -595,6 +595,16 @@ async function main() {
     '  # set MCP_TRUST_CLOUDFLARE_ACCESS_ACKNOWLEDGED=true only when intentionally trusting Access headers/assertions',
   );
   console.log('  wrangler kv:key put --binding OAUTH_KV oauth_contract_check ok');
+  if (!process.env.CLOUDFLARE_API_TOKEN?.trim()) {
+    warn(
+      'CLOUDFLARE_API_TOKEN is not set. Run `pnpm run cloudflare:waf:ensure` after creating a Zone.WAF Edit token to allow OAuth monitoring probes through Bot Fight / BIC.',
+    );
+  } else {
+    ok(
+      'CLOUDFLARE_API_TOKEN is present. Run `pnpm run cloudflare:waf:ensure` explicitly to install or update the OAuth probe WAF rule.',
+    );
+  }
+  console.log('  pnpm run cloudflare:waf:ensure   # idempotent WAF rule for OAuth probes');
   console.log('  pnpm run cloudflare:deploy');
 
   if (hasCriticalError) {

--- a/scripts/cloudflare/ensure-waf-probe-access.mjs
+++ b/scripts/cloudflare/ensure-waf-probe-access.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * Idempotently allow the hosted OAuth monitoring probes through Cloudflare edge
+ * security without weakening protections for normal browser traffic.
+ *
+ * Requires CLOUDFLARE_API_TOKEN with Zone.Zone Read + Zone.WAF Edit.
+ */
+
+import { pathToFileURL } from 'node:url';
+import { cloudflareRequest, resolveZoneId } from './lib/cloudflare-api.mjs';
+
+const DEFAULT_ZONE_NAME = 'blakeoxford.com';
+const DEFAULT_HOSTNAME = 'courtlistenermcp.blakeoxford.com';
+const PROBE_RULE_REF = 'allow_oauth_probe_monitoring';
+const CUSTOM_FIREWALL_PHASE = 'http_request_firewall_custom';
+
+export function buildProbeSkipRule({
+  hostname = DEFAULT_HOSTNAME,
+  description = 'Allow hosted OAuth CI/probe traffic',
+} = {}) {
+  return {
+    ref: PROBE_RULE_REF,
+    description,
+    expression: `(http.host eq "${hostname}" and http.user_agent contains "courtlistener-mcp-oauth-probe")`,
+    action: 'skip',
+    enabled: true,
+    action_parameters: {
+      phases: ['http_request_sbfm', 'http_ratelimit'],
+      products: ['bic', 'uaBlock', 'securityLevel'],
+    },
+    logging: {
+      enabled: true,
+    },
+  };
+}
+
+export async function fetchCustomFirewallEntrypoint(zoneId) {
+  return cloudflareRequest(`/zones/${zoneId}/rulesets/phases/${CUSTOM_FIREWALL_PHASE}/entrypoint`);
+}
+
+export async function ensureProbeSkipRule(options = {}) {
+  const zoneId = await resolveZoneId({
+    zoneName: options.zoneName ?? process.env.CLOUDFLARE_ZONE_NAME ?? DEFAULT_ZONE_NAME,
+    zoneId: options.zoneId ?? process.env.CLOUDFLARE_ZONE_ID,
+  });
+
+  const hostname = options.hostname ?? process.env.CLOUDFLARE_MCP_HOSTNAME ?? DEFAULT_HOSTNAME;
+  const entrypoint = await fetchCustomFirewallEntrypoint(zoneId);
+  if (!entrypoint?.id) {
+    throw new Error(`Missing ${CUSTOM_FIREWALL_PHASE} entrypoint ruleset for zone ${zoneId}.`);
+  }
+
+  const desiredRule = buildProbeSkipRule({ hostname });
+  const rules = Array.isArray(entrypoint.rules) ? [...entrypoint.rules] : [];
+  const existing = rules.find((rule) => rule.ref === PROBE_RULE_REF) ?? null;
+
+  if (existing && rulesEquivalent(existing, desiredRule)) {
+    return {
+      changed: false,
+      zoneId,
+      rulesetId: entrypoint.id,
+      hostname,
+      ruleRef: PROBE_RULE_REF,
+    };
+  }
+
+  const updatedRule = existing?.id
+    ? await updateProbeRule(zoneId, entrypoint.id, existing.id, desiredRule)
+    : await createProbeRule(zoneId, entrypoint.id, desiredRule);
+
+  return {
+    changed: true,
+    zoneId,
+    rulesetId: entrypoint.id,
+    hostname,
+    ruleRef: updatedRule.ref ?? PROBE_RULE_REF,
+    ruleId: updatedRule.id ?? existing?.id ?? null,
+  };
+}
+
+function rulesEquivalent(existing, desired) {
+  return JSON.stringify(canonicalizeRule(existing)) === JSON.stringify(canonicalizeRule(desired));
+}
+
+function canonicalizeRule(rule) {
+  return {
+    ref: rule?.ref ?? null,
+    description: rule?.description ?? '',
+    expression: rule?.expression ?? '',
+    action: rule?.action ?? '',
+    enabled: rule?.enabled !== false,
+    loggingEnabled: rule?.logging?.enabled !== false,
+    phases: canonicalizeList(rule?.action_parameters?.phases),
+    products: canonicalizeList(rule?.action_parameters?.products),
+  };
+}
+
+function canonicalizeList(values) {
+  return Array.isArray(values) ? [...values].map(String).sort() : [];
+}
+
+async function createProbeRule(zoneId, rulesetId, rule) {
+  const result = await cloudflareRequest(`/zones/${zoneId}/rulesets/${rulesetId}/rules`, {
+    method: 'POST',
+    body: { rules: [rule] },
+  });
+  return unwrapRuleResult(result, PROBE_RULE_REF);
+}
+
+async function updateProbeRule(zoneId, rulesetId, ruleId, rule) {
+  const result = await cloudflareRequest(`/zones/${zoneId}/rulesets/${rulesetId}/rules/${ruleId}`, {
+    method: 'PATCH',
+    body: rule,
+  });
+  return unwrapRuleResult(result, PROBE_RULE_REF);
+}
+
+function unwrapRuleResult(result, fallbackRef) {
+  if (Array.isArray(result)) {
+    return result[0] ?? { ref: fallbackRef };
+  }
+  if (result && Array.isArray(result.rules)) {
+    return (
+      result.rules.find((rule) => rule.ref === fallbackRef) ??
+      result.rules[0] ?? { ref: fallbackRef }
+    );
+  }
+  return result ?? { ref: fallbackRef };
+}
+
+async function main() {
+  const result = await ensureProbeSkipRule();
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        changed: result.changed,
+        zoneId: result.zoneId,
+        rulesetId: result.rulesetId,
+        hostname: result.hostname,
+        ruleRef: result.ruleRef,
+        message: result.changed
+          ? 'Installed or updated OAuth probe skip rule.'
+          : 'OAuth probe skip rule already present.',
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/cloudflare/ensure-waf-probe-access.mjs
+++ b/scripts/cloudflare/ensure-waf-probe-access.mjs
@@ -103,7 +103,7 @@ function canonicalizeList(values) {
 async function createProbeRule(zoneId, rulesetId, rule) {
   const result = await cloudflareRequest(`/zones/${zoneId}/rulesets/${rulesetId}/rules`, {
     method: 'POST',
-    body: { rules: [rule] },
+    body: rule,
   });
   return unwrapRuleResult(result, PROBE_RULE_REF);
 }

--- a/scripts/cloudflare/lib/cloudflare-api.mjs
+++ b/scripts/cloudflare/lib/cloudflare-api.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const API_BASE = 'https://api.cloudflare.com/client/v4';
+
+export function requireEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export function getCloudflareCredentials() {
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+  if (apiToken) {
+    return { apiToken };
+  }
+  throw new Error('Set CLOUDFLARE_API_TOKEN with Zone.WAF Edit and Zone.Zone Read permissions.');
+}
+
+export async function cloudflareRequest(path, { method = 'GET', body } = {}) {
+  const { apiToken } = getCloudflareCredentials();
+  const response = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload.success === false) {
+    const errors = Array.isArray(payload.errors)
+      ? payload.errors.map((entry) => entry.message).join('; ')
+      : response.statusText;
+    throw new Error(`Cloudflare API ${method} ${path} failed: ${errors}`);
+  }
+  return payload.result;
+}
+
+export async function resolveZoneId({ zoneName, zoneId }) {
+  if (zoneId?.trim()) {
+    return zoneId.trim();
+  }
+  const name = zoneName?.trim();
+  if (!name) {
+    throw new Error('Provide CLOUDFLARE_ZONE_ID or CLOUDFLARE_ZONE_NAME.');
+  }
+  const zones = await cloudflareRequest(`/zones?name=${encodeURIComponent(name)}&status=active`);
+  const match = zones?.find?.((zone) => zone.name === name) ?? zones?.[0];
+  if (!match?.id) {
+    throw new Error(`No active Cloudflare zone found for name: ${name}`);
+  }
+  return match.id;
+}

--- a/scripts/cloudflare/print-zone-id.mjs
+++ b/scripts/cloudflare/print-zone-id.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+import { resolveZoneId } from './lib/cloudflare-api.mjs';
+
+async function main() {
+  const zoneName = process.env.CLOUDFLARE_ZONE_NAME?.trim() || 'blakeoxford.com';
+  const zoneId = await resolveZoneId({ zoneName });
+  console.log(JSON.stringify({ zoneName, zoneId }, null, 2));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/test/unit/test-cloudflare-waf-probe.mjs
+++ b/test/unit/test-cloudflare-waf-probe.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  buildProbeSkipRule,
+  ensureProbeSkipRule,
+} from '../../scripts/cloudflare/ensure-waf-probe-access.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalApiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+function jsonResponse(result) {
+  return new Response(JSON.stringify({ success: true, result }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('cloudflare waf probe rule', () => {
+  beforeEach(() => {
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.env.CLOUDFLARE_API_TOKEN = originalApiToken;
+  });
+
+  it('builds a skip rule for the hosted OAuth monitor user-agent', () => {
+    const rule = buildProbeSkipRule({ hostname: 'courtlistenermcp.example.com' });
+    assert.equal(rule.ref, 'allow_oauth_probe_monitoring');
+    assert.equal(rule.action, 'skip');
+    assert.match(rule.expression, /courtlistenermcp\.example\.com/);
+    assert.match(rule.expression, /courtlistener-mcp-oauth-probe/);
+    assert.deepEqual(rule.action_parameters.phases, ['http_request_sbfm', 'http_ratelimit']);
+    assert.ok(rule.action_parameters.products.includes('bic'));
+  });
+
+  it('does not update Cloudflare when the probe rule already matches', async () => {
+    const calls = [];
+    globalThis.fetch = async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls.push({ url, method: init.method ?? 'GET' });
+
+      if (url.includes('/rulesets/phases/http_request_firewall_custom/entrypoint')) {
+        return jsonResponse({
+          id: 'ruleset-1',
+          rules: [
+            {
+              id: 'rule-1',
+              ref: 'allow_oauth_probe_monitoring',
+              description: 'Allow hosted OAuth CI/probe traffic',
+              expression:
+                '(http.host eq "courtlistenermcp.example.com" and http.user_agent contains "courtlistener-mcp-oauth-probe")',
+              action: 'skip',
+              enabled: true,
+              action_parameters: {
+                products: ['securityLevel', 'uaBlock', 'bic'],
+                phases: ['http_ratelimit', 'http_request_sbfm'],
+              },
+              logging: { enabled: true },
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    const result = await ensureProbeSkipRule({
+      zoneId: 'zone-1',
+      hostname: 'courtlistenermcp.example.com',
+    });
+
+    assert.equal(result.changed, false);
+    assert.deepEqual(calls, [
+      {
+        url: 'https://api.cloudflare.com/client/v4/zones/zone-1/rulesets/phases/http_request_firewall_custom/entrypoint',
+        method: 'GET',
+      },
+    ]);
+  });
+
+  it('creates the probe rule when it does not exist', async () => {
+    const calls = [];
+    globalThis.fetch = async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init.method ?? 'GET';
+      const body = init.body ? JSON.parse(init.body) : undefined;
+      calls.push({ url, method, body });
+
+      if (url.includes('/rulesets/phases/http_request_firewall_custom/entrypoint')) {
+        return jsonResponse({ id: 'ruleset-1', rules: [] });
+      }
+      if (url.endsWith('/rulesets/ruleset-1/rules')) {
+        return jsonResponse({
+          rules: [{ id: 'rule-1', ref: 'allow_oauth_probe_monitoring' }],
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    const result = await ensureProbeSkipRule({
+      zoneId: 'zone-1',
+      hostname: 'courtlistenermcp.example.com',
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.ruleId, 'rule-1');
+    assert.equal(calls[1].method, 'POST');
+    assert.deepEqual(calls[1].body, {
+      rules: [buildProbeSkipRule({ hostname: 'courtlistenermcp.example.com' })],
+    });
+  });
+
+  it('patches only the probe rule when its definition changes', async () => {
+    const calls = [];
+    globalThis.fetch = async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init.method ?? 'GET';
+      const body = init.body ? JSON.parse(init.body) : undefined;
+      calls.push({ url, method, body });
+
+      if (url.includes('/rulesets/phases/http_request_firewall_custom/entrypoint')) {
+        return jsonResponse({
+          id: 'ruleset-1',
+          rules: [
+            {
+              id: 'rule-1',
+              ref: 'allow_oauth_probe_monitoring',
+              description: 'Old description',
+              expression:
+                '(http.host eq "courtlistenermcp.example.com" and http.user_agent contains "courtlistener-mcp-oauth-probe")',
+              action: 'skip',
+              enabled: true,
+              action_parameters: {
+                phases: ['http_request_sbfm'],
+                products: ['bic'],
+              },
+              logging: { enabled: true },
+            },
+            {
+              id: 'rule-2',
+              ref: 'leave_other_rules_alone',
+            },
+          ],
+        });
+      }
+      if (url.endsWith('/rulesets/ruleset-1/rules/rule-1')) {
+        return jsonResponse({
+          id: 'rule-1',
+          ref: 'allow_oauth_probe_monitoring',
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    const result = await ensureProbeSkipRule({
+      zoneId: 'zone-1',
+      hostname: 'courtlistenermcp.example.com',
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.ruleId, 'rule-1');
+    assert.equal(calls[1].method, 'PATCH');
+    assert.equal(
+      calls[1].url,
+      'https://api.cloudflare.com/client/v4/zones/zone-1/rulesets/ruleset-1/rules/rule-1',
+    );
+    assert.deepEqual(
+      calls[1].body,
+      buildProbeSkipRule({ hostname: 'courtlistenermcp.example.com' }),
+    );
+    assert.equal(calls.length, 2);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,10 @@
   "compatibility_date": "2026-03-02",
   "main": "src/worker.ts",
   "workers_dev": false,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
   "vars": {
     "MCP_OAUTH_BACKEND": "cloudflare",
     "MCP_ALLOW_DEV_FALLBACK": "false",
@@ -17,6 +21,10 @@
     {
       "binding": "OAUTH_KV",
       "id": "56b997590e3344c98bf6875ae8b522c0",
+    },
+    {
+      "binding": "ASYNC_JOBS_KV",
+      "id": "9903b38dea3d44399ed23ed4b0a51777",
     },
   ],
   "analytics_engine_datasets": [


### PR DESCRIPTION
## Summary\n- add an explicit Cloudflare WAF helper to allow the hosted OAuth probe user-agent through bot/rate-limit edge protections\n- keep cloudflare:check read-only and add targeted scripts/tests for the WAF rule upsert flow\n- add an optional Terraform ruleset example plus the missing ASYNC_JOBS_KV / observability wrangler config updates\n\n## Validation\n- pnpm run format:check\n- pnpm run lint\n- pnpm run typecheck\n- pnpm run build\n- npm run test:unit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Cloudflare edge security behavior (adds a `skip` ruleset for specific traffic) and updates deployment config; mistakes could unintentionally broaden bypass scope or affect WAF/rate limiting.
> 
> **Overview**
> **Allows hosted OAuth monitoring probes to reach the Worker even when Cloudflare Bot Fight/BIC or rate limiting is enabled.** This introduces an idempotent `cloudflare:waf:ensure` script (plus shared Cloudflare API helpers and unit tests) that creates/patches a custom firewall ruleset `skip` rule keyed to the `courtlistener-mcp-oauth-probe` user-agent and configured hostname.
> 
> Adds an optional Terraform example (`infra/cloudflare/terraform`) to manage the same ruleset declaratively, updates `cloudflare:check` messaging to guide operators toward the new flow, and tweaks `wrangler.jsonc` to enable observability and include the missing `ASYNC_JOBS_KV` binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c055572d230a0d5f5e6b4d7b9129de0f46e7817a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->