### PR TITLE
fix(async): guard cancel handler to mcp_async_cancel_job only

### DIFF
--- a/src/server/worker-async-queue-runtime.ts
+++ b/src/server/worker-async-queue-runtime.ts
@@ -5,6 +5,7 @@ import type { Logger } from '../infrastructure/logger.js';
 import { runWithPrincipalContext } from '../infrastructure/principal-context.js';
 import {
   createAsyncEnvelope,
+  MCP_ASYNC_CONTROL_TOOLS,
   resolveBoundedPositiveInt,
   type AsyncExecutionDirective,
   type AsyncJobSnapshot,
@@ -186,6 +187,13 @@ export class CloudflareAsyncQueueWorkflow {
         job: snapshot(job),
         result: null,
       });
+    }
+
+    if (request.params.name !== MCP_ASYNC_CONTROL_TOOLS.cancel) {
+      return createAsyncEnvelope(
+        { success: false, error: `Unsupported control tool: ${request.params.name}` },
+        true,
+      );
     }
 
     job.cancellationRequested = true;

--- a/test/unit/test-worker-async-queue-runtime.ts
+++ b/test/unit/test-worker-async-queue-runtime.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import {
+  CloudflareAsyncQueueWorkflow,
   processAsyncQueueMessage,
   type AsyncJobMessage,
 } from '../../src/server/worker-async-queue-runtime.js';
@@ -45,6 +46,110 @@ class MemoryKvNamespace {
     this.store.set(key, value);
   }
 }
+
+function parsePayload(result: CallToolResult): Record<string, unknown> {
+  assert.ok(result.content.length > 0);
+  const first = result.content[0];
+  assert.strictEqual(first.type, 'text');
+  return JSON.parse(first.text) as Record<string, unknown>;
+}
+
+async function createQueuedJob(kv: MemoryKvNamespace, jobId: string): Promise<void> {
+  const now = Date.now();
+  const request: CallToolRequest = {
+    method: 'tools/call',
+    params: {
+      name: 'delayed_flaky',
+      arguments: {},
+    },
+  };
+
+  await kv.put(
+    `job:${jobId}`,
+    JSON.stringify({
+      id: jobId,
+      toolName: request.params.name,
+      request,
+      requestId: 'request-1',
+      status: 'queued',
+      createdAtMs: now,
+      updatedAtMs: now,
+      expiresAtMs: now + 60_000,
+      attempts: {
+        current: 0,
+        max: 3,
+      },
+      retryDelayMs: 1,
+      cancellationRequested: false,
+      queuedAtMs: now,
+    }),
+  );
+}
+
+describe('CloudflareAsyncQueueWorkflow.handleControlToolCall', () => {
+  it('rejects unsupported control tools without mutating the job', async () => {
+    const kv = new MemoryKvNamespace();
+    const jobId = 'job-unsupported-control';
+    await createQueuedJob(kv, jobId);
+
+    const workflow = new CloudflareAsyncQueueWorkflow(
+      {
+        ASYNC_JOBS_KV: kv as unknown as KVNamespace,
+        ASYNC_TOOL_QUEUE: {
+          send: async () => undefined,
+        } as unknown as Queue<AsyncJobMessage>,
+      },
+      { logger: new SilentLogger() as never },
+    );
+
+    const result = await workflow.handleControlToolCall({
+      method: 'tools/call',
+      params: {
+        name: 'mcp_async_future_control',
+        arguments: { jobId },
+      },
+    });
+
+    const payload = parsePayload(result);
+    assert.equal(result.isError, true);
+    assert.equal(payload.success, false);
+    assert.match(String(payload.error), /Unsupported control tool/);
+
+    const stored = (await kv.get(`job:${jobId}`, 'json')) as Record<string, unknown>;
+    assert.equal(stored.status, 'queued');
+    assert.equal(stored.cancellationRequested, false);
+  });
+
+  it('cancels queued jobs for mcp_async_cancel_job', async () => {
+    const kv = new MemoryKvNamespace();
+    const jobId = 'job-cancel-queued';
+    await createQueuedJob(kv, jobId);
+
+    const workflow = new CloudflareAsyncQueueWorkflow(
+      {
+        ASYNC_JOBS_KV: kv as unknown as KVNamespace,
+        ASYNC_TOOL_QUEUE: {
+          send: async () => undefined,
+        } as unknown as Queue<AsyncJobMessage>,
+      },
+      { logger: new SilentLogger() as never },
+    );
+
+    const result = await workflow.handleControlToolCall({
+      method: 'tools/call',
+      params: {
+        name: 'mcp_async_cancel_job',
+        arguments: { jobId },
+      },
+    });
+
+    const payload = parsePayload(result);
+    assert.equal(payload.success, true);
+    const job = payload.job as Record<string, unknown>;
+    assert.equal(job.status, 'failed');
+    assert.equal((job.error as Record<string, unknown>).code, 'cancelled');
+  });
+});
 
 describe('processAsyncQueueMessage', () => {
   it('preserves cancellationRequested when cancellation is persisted during execution', async () => {


### PR DESCRIPTION
## Summary
`CloudflareAsyncQueueWorkflow.handleControlToolCall` used implicit fall-through into the cancel path for any tool name other than get/status/result. That is safe today because `isAsyncControlToolName` only routes three tools here, but a future fourth control tool would silently cancel jobs.

This PR adds an explicit guard so only `mcp_async_cancel_job` reaches cancellation logic.

## Changes
- Reject unsupported control tools with a clear error envelope
- Unit tests: unsupported tool does not mutate KV job; cancel still works for queued jobs

## Test plan
- [x] `pnpm exec tsx --test test/unit/test-worker-async-queue-runtime.ts`
- [ ] CI Required Checks Gate

Supersedes stale branch `fix/async-control-handler-fall-through` (no PR).


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change to async job control routing that prevents unintended cancellations; behavior change is covered by new unit tests.
> 
> **Overview**
> **Async control tool handling is now explicitly validated.** `CloudflareAsyncQueueWorkflow.handleControlToolCall` no longer falls through to the cancel path for unknown control tools; it only performs cancellation when `request.params.name` matches `MCP_ASYNC_CONTROL_TOOLS.cancel`, otherwise returning an error envelope.
> 
> **Tests added** to ensure unsupported control tools do not mutate the KV-stored job state and that queued jobs are still cancelled correctly via `mcp_async_cancel_job`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d89aa4a8e2c6d31b444e5bcb5a15f828a71c9fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->