### PR TITLE
ci: auto-approve PRs opened by repository owner

### DIFF
--- a/.github/workflows/auto-approve-owner.yml
+++ b/.github/workflows/auto-approve-owner.yml
@@ -1,0 +1,42 @@
+name: Auto Approve Owner PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'blakeox' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR for repository owner
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            const alreadyApproved = reviews.some(
+              (review) =>
+                review.user?.type === 'Bot' &&
+                review.state === 'APPROVED' &&
+                review.body?.includes('Auto-approved for repository owner'),
+            );
+            if (alreadyApproved) {
+              core.info('Owner PR already has an auto-approval review.');
+              return;
+            }
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              event: 'APPROVE',
+              body: 'Auto-approved for repository owner (GitHub does not allow self-approval).',
+            });


### PR DESCRIPTION
## Summary
GitHub does not allow PR authors to approve their own pull requests. This workflow adds a bot approval when `blakeox` opens a PR so solo-maintainer merges are not blocked.

Also updated branch protection on `dev` and `main`:
- `required_conversation_resolution` → **false** (bot review threads no longer block merge)

## Test plan
- [ ] Open a test PR as blakeox and confirm github-actions bot leaves an approval

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a `pull_request_target` GitHub Actions workflow that programmatically submits an approving review, which can weaken branch protection expectations if mis-scoped or abused.
> 
> **Overview**
> Introduces a new GitHub Actions workflow (`.github/workflows/auto-approve-owner.yml`) that automatically approves non-draft PRs opened by `blakeox` using `actions/github-script`.
> 
> The job checks existing PR reviews to avoid duplicate bot approvals, then creates an `APPROVE` review with a fixed message when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c1d850b2b4c191fc76101e5070d8a53fc72d3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->