### PR TITLE
chore: sync dev with main after promote #1620

### DIFF
--- a/.github/workflows/regenerate-spa-assets.yml
+++ b/.github/workflows/regenerate-spa-assets.yml
@@ -9,9 +9,11 @@ on:
         type: string
   push:
     branches:
-      - fix/mcp-credential-account-ui
+      - main
+      - dev
     paths:
-      - .github/trigger-spa-regen
+      - src/web-spa/**
+      - scripts/web/build-spa-assets.mjs
 
 permissions:
   contents: write

--- a/src/web-spa/src/pages/AccountPage.tsx
+++ b/src/web-spa/src/pages/AccountPage.tsx
@@ -71,11 +71,6 @@ export function AccountPage(): React.JSX.Element {
       : hasServerSession
         ? 'Signed in'
         : 'Signed out';
-  const credentialSummary = hasToken
-    ? persisted
-      ? 'Local credential saved'
-      : 'Temporary credential loaded'
-    : 'No local credential';
   const protocolSummary =
     !hasServerSession || !hasToken
       ? 'Runtime checks locked'


### PR DESCRIPTION
Content-only sync (2 files) to satisfy linear history on dev.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI trigger update and a small UI cleanup; primary risk is increased workflow runs/auto-commits on pushes that touch `src/web-spa` or the build script.
> 
> **Overview**
> Updates the `regenerate-spa-assets` GitHub Action to run on pushes to `main`/`dev` when SPA source or `scripts/web/build-spa-assets.mjs` changes (instead of the previous branch/trigger-file gating).
> 
> Cleans up `AccountPage` by removing the unused `credentialSummary` variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fdc0bf206045022a37e04b7e3a0af21ae24e428. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->