### PR TITLE
fix: restore dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       timezone: 'America/Los_Angeles'
     open-pull-requests-limit: 5
     commit-message:
-      prefix: chore
+      prefix: chore(deps)
       include: scope
     labels:
       - dependencies
@@ -36,7 +36,7 @@ updates:
       timezone: 'America/Los_Angeles'
     open-pull-requests-limit: 3
     commit-message:
-      prefix: chore
+      prefix: chore(deps)
       include: scope
     labels:
       - dependencies


### PR DESCRIPTION
Align `dependabot.yml` commit prefix with dev (`chore(deps)`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects how Dependabot formats commit messages for update PRs.
> 
> **Overview**
> Restores Dependabot commit message formatting by changing the `commit-message.prefix` from `chore` to `chore(deps)` for both npm and GitHub Actions updates in `.github/dependabot.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be329dbfb88b8997734f963727bf984d61903961. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->