### PR TITLE
fix: clean Dependabot commit titles for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,12 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: chore(deps)
-      include: scope
     labels:
       - dependencies
       - github-actions
+    groups:
+      github-actions:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Remove `include: scope` from github-actions updates (was producing `chore(deps)(deps): …`)
- Group github-actions minor/patch bumps; majors handled deliberately

## Test plan
- [x] Config-only change

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Dependabot change; no runtime or application code affected.
> 
> **Overview**
> Updates **Dependabot** for the **github-actions** ecosystem so PR/commit titles stay readable and minor/patch bumps are batched.
> 
> **Commit messages:** Drops `commit-message.include: scope` for github-actions only (npm still uses scope). That avoids titles like `chore(deps)(deps): …` when the inferred scope is already `deps`.
> 
> **Grouping:** Adds a `github-actions` version-update group for **minor** and **patch** bumps, similar in spirit to the npm groups. **Major** action updates are not grouped, so they can still be reviewed one at a time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec5af1a0d084d649619a3d0c5579ab755cd233e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->