### PR TITLE
fix: remove duplicate scope from npm Dependabot commit titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: chore(deps)
-      include: scope
     labels:
       - dependencies
     groups:


### PR DESCRIPTION
Drop `include: scope` on npm updates to avoid `chore(deps)(deps-dev):` titles.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependabot commit-message formatting only; no runtime or dependency resolution behavior changes.
> 
> **Overview**
> Removes **`include: scope`** from the npm Dependabot **`commit-message`** block so automated dependency PRs no longer get a second scope segment in the title (e.g. **`chore(deps)(deps-dev):`** instead of a cleaner **`chore(deps):`** prefix).
> 
> Only the npm ecosystem entry is affected; GitHub Actions Dependabot config is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229201af06b431b83ff25e37ad20f15e19ff7c5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->