### PR TITLE
fix: resolve CodeQL findings and performance issue noise

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -136,7 +136,25 @@ jobs:
             [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             `;
 
-            github.rest.issues.create({
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'monitoring,regression',
+              per_page: 1,
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: title,

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
 
 const projectRoot = process.cwd();
 const wranglerConfigPath = join(projectRoot, 'wrangler.jsonc');
@@ -557,8 +558,7 @@ async function main() {
         const accessRedirectReady =
           authorizeAccessProbe.status >= 300 &&
           authorizeAccessProbe.status < 400 &&
-          (authorizeLocation.includes('/cdn-cgi/access/login') ||
-            authorizeLocation.includes('.cloudflareaccess.com'));
+          isCloudflareAccessLoginRedirect(authorizeLocation);
         if (accessRedirectReady) {
           ok('/oauth/authorize is protected by Cloudflare Access for browser auth.');
         } else {

--- a/scripts/cloudflare/url-helpers.js
+++ b/scripts/cloudflare/url-helpers.js
@@ -1,0 +1,13 @@
+/** True when a redirect targets Cloudflare Access login. */
+export function isCloudflareAccessLoginRedirect(location) {
+  if (!location) return false;
+  try {
+    const parsed = new URL(location);
+    if (parsed.pathname.includes('/cdn-cgi/access/login')) {
+      return true;
+    }
+    return parsed.hostname.endsWith('.cloudflareaccess.com');
+  } catch {
+    return false;
+  }
+}

--- a/scripts/cloudflare/url-helpers.js
+++ b/scripts/cloudflare/url-helpers.js
@@ -2,7 +2,7 @@
 export function isCloudflareAccessLoginRedirect(location) {
   if (!location) return false;
   try {
-    const parsed = new URL(location);
+    const parsed = new URL(location, 'https://placeholder.invalid');
     if (parsed.pathname.includes('/cdn-cgi/access/login')) {
       return true;
     }

--- a/src/infrastructure/strip-html-tags.ts
+++ b/src/infrastructure/strip-html-tags.ts
@@ -1,0 +1,10 @@
+/** Remove HTML tags iteratively (CodeQL-safe vs single-pass regex). */
+export function stripHtmlTags(value: string): string {
+  let current = value;
+  let previous = '';
+  while (current !== previous) {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, '');
+  }
+  return current;
+}

--- a/src/server/oauth-diagnostics.ts
+++ b/src/server/oauth-diagnostics.ts
@@ -3,7 +3,7 @@ import {
   isHostedAuthorizePath,
   isHostedLogoutPath,
 } from '../auth/oauth-contract.js';
-import { redactSecretsInText } from '../infrastructure/secret-redaction.js';
+import { redactSecretsInText, isSensitiveKeyName } from '../infrastructure/secret-redaction.js';
 import type { WorkerHostedAuthConfigDiagnostics } from './worker-upstream-oidc-config.js';
 
 const MAX_ERROR_BODY_LENGTH = 512;
@@ -542,6 +542,28 @@ export function summarizeHostedAuthSignal(
   return metadata;
 }
 
+function redactDiagnosticMetadata(metadata: DiagnosticMetadata): DiagnosticMetadata {
+  const redacted: DiagnosticMetadata = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (isSensitiveKeyName(key)) {
+      redacted[key] = '[REDACTED]';
+      continue;
+    }
+    if (typeof value === 'string') {
+      redacted[key] = redactSecretsInText(value);
+      continue;
+    }
+    if (Array.isArray(value)) {
+      redacted[key] = value.map((entry) =>
+        typeof entry === 'string' ? redactSecretsInText(entry) : entry,
+      );
+      continue;
+    }
+    redacted[key] = value;
+  }
+  return redacted;
+}
+
 export function emitOAuthDiagnostic(
   env: DiagnosticEnv,
   event: string,
@@ -552,10 +574,12 @@ export function emitOAuthDiagnostic(
   }
 
   console.error(
-    JSON.stringify({
-      timestamp: new Date().toISOString(),
-      event,
-      metadata,
-    }),
+    redactSecretsInText(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        event,
+        metadata: redactDiagnosticMetadata(metadata),
+      }),
+    ),
   );
 }

--- a/src/server/worker-ai-response-runtime.ts
+++ b/src/server/worker-ai-response-runtime.ts
@@ -1,3 +1,5 @@
+import { stripHtmlTags } from '../infrastructure/strip-html-tags.js';
+
 export function buildMcpSystemPrompt(toolName: string, hasHistory: boolean): string {
   const commonRules = [
     'ACCURACY RULES:',
@@ -331,9 +333,7 @@ function formatSearchResult(num: number, item: Record<string, unknown>): string 
   if (status) parts.push(`   Status: ${status}`);
   if (url) parts.push(`   URL: https://www.courtlistener.com${url}`);
   if (snippet) {
-    const cleanSnippet = String(snippet)
-      .replace(/<[^>]+>/g, '')
-      .slice(0, 300);
+    const cleanSnippet = stripHtmlTags(String(snippet)).slice(0, 300);
     parts.push(`   Snippet: ${cleanSnippet}`);
   }
 

--- a/src/web-spa/e2e/support/local-auth-flow-server.ts
+++ b/src/web-spa/e2e/support/local-auth-flow-server.ts
@@ -276,7 +276,7 @@ export async function startLocalAuthFlowServer(): Promise<LocalAuthFlowServer> {
       nodeResponse.end('Not found');
     } catch (error) {
       nodeResponse.statusCode = 500;
-      nodeResponse.end(error instanceof Error ? error.stack || error.message : String(error));
+      nodeResponse.end(error instanceof Error ? error.message : String(error));
     }
   });
 

--- a/src/web-spa/src/__tests__/worker-logic.test.ts
+++ b/src/web-spa/src/__tests__/worker-logic.test.ts
@@ -4,6 +4,7 @@
  * for direct unit testing. Keep in sync with src/worker.ts.
  */
 import { describe, it, expect } from 'vitest';
+import { stripHtmlTags } from '../../../infrastructure/strip-html-tags.js';
 
 // ─── Duplicated pure functions from worker.ts ───────────────────
 
@@ -332,9 +333,7 @@ function formatSearchResult(num: number, item: Record<string, unknown>): string 
   if (status) parts.push(`   Status: ${status}`);
   if (url) parts.push(`   URL: https://www.courtlistener.com${url}`);
   if (snippet) {
-    const cleanSnippet = String(snippet)
-      .replace(/<[^>]+>/g, '')
-      .slice(0, 300);
+    const cleanSnippet = stripHtmlTags(String(snippet)).slice(0, 300);
     parts.push(`   Snippet: ${cleanSnippet}`);
   }
 

--- a/test/enterprise/integration/test-middleware-integration.ts
+++ b/test/enterprise/integration/test-middleware-integration.ts
@@ -69,9 +69,20 @@ class MockInputSanitizer {
     let sanitized = input;
 
     if (typeof input === 'string') {
-      if (/<script[\s>\/]/i.test(input)) {
+      const lowerInput = input.toLowerCase();
+      if (lowerInput.includes('<script')) {
         violations.push({ type: 'XSS', severity: 'high' });
-        sanitized = input.replace(/<script[\s>\/][^]*?<\/script>/gi, '[SCRIPT_REMOVED]');
+        let sanitizedText = input;
+        let scriptIndex = sanitizedText.toLowerCase().indexOf('<script');
+        while (scriptIndex !== -1) {
+          const endIndex = sanitizedText.toLowerCase().indexOf('</script>', scriptIndex);
+          if (endIndex === -1) {
+            break;
+          }
+          sanitizedText = `${sanitizedText.slice(0, scriptIndex)}[SCRIPT_REMOVED]${sanitizedText.slice(endIndex + '</script>'.length)}`;
+          scriptIndex = sanitizedText.toLowerCase().indexOf('<script');
+        }
+        sanitized = sanitizedText;
       }
       if (input.includes('DROP TABLE')) {
         violations.push({ type: 'SQL_INJECTION', severity: 'high' });

--- a/test/unit/test-worker-oauth-provider-runtime.ts
+++ b/test/unit/test-worker-oauth-provider-runtime.ts
@@ -146,12 +146,30 @@ describe('worker OAuth provider runtime', () => {
       {
         getRequestOrigin: (request) => request.headers.get('origin'),
         getCachedAllowedOrigins: () => ['https://auth.example'],
-        buildCorsHeaders: (origin, allowedOrigins) =>
-          new Headers({
-            'access-control-allow-origin':
-              origin && allowedOrigins.includes('https://auth.example') ? origin : 'null',
+        buildCorsHeaders: (origin, allowedOrigins) => {
+          let allowOrigin = 'null';
+          if (origin) {
+            try {
+              const normalizedOrigin = new URL(origin).origin;
+              const isAllowed = allowedOrigins.some((allowed) => {
+                try {
+                  return new URL(allowed).origin === normalizedOrigin;
+                } catch {
+                  return false;
+                }
+              });
+              if (isAllowed) {
+                allowOrigin = normalizedOrigin;
+              }
+            } catch {
+              // ignore invalid origin values in tests
+            }
+          }
+          return new Headers({
+            'access-control-allow-origin': allowOrigin,
             vary: 'Origin',
-          }),
+          });
+        },
       },
     );
 


### PR DESCRIPTION
## Summary
- Fix 7 open CodeQL alerts (HTML sanitization, URL checks, OAuth log redaction, stack traces, test sanitizer)
- Deduplicate performance regression GitHub issues (comment on existing open issue)

## Test plan
- [x] typecheck + unit tests pass locally
- [ ] CI Required Checks Gate
- [ ] Close #1536, #1537, #1606 after merge

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth diagnostic logging and CORS origin matching (test/runtime-adjacent); changes are hardening and CI deduplication rather than new auth features.
> 
> **Overview**
> Addresses **CodeQL** findings and **performance monitoring** duplicate issues.
> 
> **CI:** On performance regression failure, the workflow now **comments on an existing open** issue labeled `monitoring` + `regression` instead of opening another issue; only creates a new issue when none is open.
> 
> **Security / static analysis:** Adds shared **`stripHtmlTags`** (iterative stripping) for CourtListener snippets in the AI response path; **`isCloudflareAccessLoginRedirect`** parses redirect URLs for Cloudflare Access checks in `check-setup.js`. **OAuth diagnostics** redact sensitive metadata keys and run **`redactSecretsInText`** on the full log line. E2E local auth server **500** responses return **message only** (no stack). Enterprise mock sanitizer removes `<script>` blocks via string scanning instead of regex. Registration **CORS** test helper compares origins via **`URL` normalization** rather than raw string membership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc17327a375d674d0ca38bb1033a6990331b6b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->