### PR TITLE
fix: avoid stack trace exposure in e2e auth helper

### DIFF
--- a/src/web-spa/e2e/support/local-auth-flow-server.ts
+++ b/src/web-spa/e2e/support/local-auth-flow-server.ts
@@ -274,9 +274,9 @@ export async function startLocalAuthFlowServer(): Promise<LocalAuthFlowServer> {
 
       nodeResponse.statusCode = 404;
       nodeResponse.end('Not found');
-    } catch (error) {
+    } catch {
       nodeResponse.statusCode = 500;
-      nodeResponse.end(error instanceof Error ? error.message : String(error));
+      nodeResponse.end('Internal server error');
     }
   });
 


### PR DESCRIPTION
Return a generic 500 body from the local auth flow test server.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper change with no production auth or API behavior impact.
> 
> **Overview**
> The Playwright **local auth flow** HTTP server no longer returns exception messages in 500 responses. The outer `catch` now always responds with a fixed **Internal server error** body instead of surfacing `Error.message` or stringified errors, which could leak stack or internal details to clients during e2e runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a65bf616c313e761a77a9eeb5518c16339d2370. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->