### PR TITLE
fix: unblock OAuth approve form under CSP for Cursor MCP

### DIFF
--- a/src/server/worker-auth-handoff-routes.ts
+++ b/src/server/worker-auth-handoff-routes.ts
@@ -2053,8 +2053,16 @@ async function buildApprovalPageResponse<
     headers.append('Set-Cookie', csrfCookieHeader);
   }
   const nonce = deps.generateCspNonce();
-  const approveActionUrl = new URL(HOSTED_MCP_BROWSER_AUTH_CONTRACT.paths.approve, request.url);
-  approveActionUrl.searchParams.set('return_to', returnTo);
+  const workerOrigin = new URL(request.url).origin;
+  const formActionOrigins = [workerOrigin];
+  if (
+    redirectUri &&
+    (redirectUri.protocol === 'http:' || redirectUri.protocol === 'https:') &&
+    redirectUri.origin !== 'null' &&
+    redirectUri.origin !== workerOrigin
+  ) {
+    formActionOrigins.push(redirectUri.origin);
+  }
 
   return deps.htmlResponse(
     renderAuthApprovalPage({
@@ -2063,14 +2071,13 @@ async function buildApprovalPageResponse<
       scope: Array.isArray(authRequest.scope) ? authRequest.scope : [],
       csrfToken,
       returnTo,
-      approveAction: `${approveActionUrl.pathname}${approveActionUrl.search}`,
+      approveAction: HOSTED_MCP_BROWSER_AUTH_CONTRACT.paths.approve,
       logoutHref: buildLogoutUrl(request, returnTo),
       nonce,
     }),
     nonce,
     headers,
-    // OAuth loopback and hosted callbacks rely on explicit callback origins in the CSP.
-    redirectUri ? { formActionOrigins: [redirectUri.origin] } : undefined,
+    { formActionOrigins },
   );
 }
 

--- a/src/server/worker-response-runtime.ts
+++ b/src/server/worker-response-runtime.ts
@@ -177,14 +177,16 @@ function applySecurityHeaders(
   );
 }
 
-function normalizeFormActionOrigins(origins: string[]): string[] {
+export function normalizeFormActionOrigins(origins: string[]): string[] {
   const uniqueOrigins = new Set<string>();
   for (const candidate of origins) {
-    const normalized = candidate.trim();
-    if (!normalized) continue;
+    const normalized = String(candidate ?? '').trim();
+    if (!normalized || normalized === 'null') continue;
     try {
-      const origin = new URL(normalized).origin;
-      if (origin === 'null' || origin === 'file://') continue;
+      const parsed = new URL(normalized);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
+      const origin = parsed.origin;
+      if (!origin || origin === 'null' || origin === 'file://') continue;
       uniqueOrigins.add(origin);
     } catch {
       continue;

--- a/test/unit/test-worker-auth-handoff-routes.ts
+++ b/test/unit/test-worker-auth-handoff-routes.ts
@@ -822,7 +822,7 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     const approvalHtml = await getResponse.text();
     assert.match(approvalHtml, /Approve OAuth access/);
     assert.match(approvalHtml, /name="return_to"/);
-    assert.match(approvalHtml, /action="\/oauth\/approve\?return_to=/);
+    assert.match(approvalHtml, /action="\/oauth\/approve"/);
     assert.match(approvalHtml, /worker\.example\/authorize\?/);
     const responseCookies = getResponse.headers.getSetCookie();
     const setCookie = String(getResponse.headers.get('set-cookie'));
@@ -835,7 +835,7 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     assert.ok(responseCookies.some((cookie) => cookie.startsWith('clmcp_csrf=csrf-token-123')));
     assert.match(
       getResponse.headers.get('content-security-policy') ?? '',
-      /form-action 'self' https:\/\/chatgpt\.com/,
+      /form-action 'self' https:\/\/worker\.example https:\/\/chatgpt\.com/,
     );
     const approvalCorrelationId = getResponse.headers.get('x-hosted-auth-correlation-id');
     assert.match(String(approvalCorrelationId), /^[A-Za-z0-9_-]{8,}$/);
@@ -949,6 +949,54 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     assert.match(String(postResponse.headers.get('x-hosted-auth-approval-duration-ms')), /^\d+$/);
     assert.match(String(postResponse.headers.get('set-cookie')), /clauth_approve=;/);
     assert.equal(completionCount, 1);
+
+    completionCount = 0;
+    const cursorAuthorizeUrl =
+      'https://worker.example/oauth/authorize?response_type=code&client_id=cursor-client&redirect_uri=cursor%3A%2F%2Fanysphere.cursor-mcp%2Foauth%2Fcallback&state=cursor-state&scope=legal%3Aread&code_challenge=challenge&code_challenge_method=S256';
+    const cursorApprovalUrl = `https://worker.example/oauth/approve?return_to=${encodeURIComponent(cursorAuthorizeUrl)}`;
+    const cursorApprovalResponse = await handleWorkerAuthHandoffRoutes({
+      request: new Request(cursorApprovalUrl, {
+        headers: { cookie: 'clmcp_ui=signed-session' },
+      }),
+      url: new URL(cursorApprovalUrl),
+      env: {
+        OIDC_ISSUER: 'https://issuer.example',
+        OIDC_AUDIENCE: 'https://worker.example',
+        MCP_AUTH_OIDC_CLIENT_ID: 'oidc-client-id',
+        MCP_AUTH_OIDC_CLIENT_SECRET: 'oidc-client-secret',
+        MCP_UI_SESSION_SECRET: 'abcdefghijklmnopqrstuvwxyz123456',
+      },
+      deps: {
+        jsonError,
+        generateCspNonce: () => 'nonce',
+        htmlResponse,
+        workerUiSessionRuntime: {
+          getUiSessionSecret: () => 'abcdefghijklmnopqrstuvwxyz123456',
+          resolveUiSession: async () => ({ kind: 'authenticated', userId: 'user-123' }),
+          createUiSessionState: async () => null,
+          getOrCreateCsrfCookieHeader: () => 'clmcp_csrf=csrf-token-123; Path=/; SameSite=Lax',
+          isSecureCookieRequest: () => true,
+        },
+        getOAuthHelpers: () => ({
+          parseAuthRequest: async () => ({ scope: ['legal:read'] }),
+          completeAuthorization: async () => ({
+            redirectTo:
+              'cursor://anysphere.cursor-mcp/oauth/callback?code=worker-code&state=cursor-state',
+          }),
+        }),
+        buildHostedOAuthCompletionDetails: () => ({ metadata: {}, props: {} }),
+        resolveGrantedScopes: () => ['legal:read'],
+      },
+    });
+
+    assert.equal(cursorApprovalResponse.status, 200);
+    const cursorApprovalHtml = await cursorApprovalResponse.text();
+    assert.match(cursorApprovalHtml, /action="\/oauth\/approve"/);
+    assert.match(cursorApprovalHtml, /anysphere\.cursor-mcp/);
+    const cursorCsp = cursorApprovalResponse.headers.get('content-security-policy') ?? '';
+    assert.match(cursorCsp, /form-action 'self' https:\/\/worker\.example/);
+    assert.doesNotMatch(cursorCsp, /cursor:/);
+    assert.doesNotMatch(cursorCsp, /\bnull\b/);
 
     completionCount = 0;
     const returnToParam = new URL(approvalUrl).searchParams.get('return_to');

--- a/test/unit/test-worker-response-runtime.ts
+++ b/test/unit/test-worker-response-runtime.ts
@@ -69,6 +69,21 @@ describe('worker response runtime', () => {
     );
   });
 
+  it('ignores opaque and custom-scheme origins in HTML form-action CSP', () => {
+    const response = htmlResponse('<html></html>', 'nonce', undefined, {
+      formActionOrigins: [
+        'null',
+        'cursor://anysphere.cursor-mcp/oauth/callback',
+        'https://worker.example',
+      ],
+    });
+
+    const csp = response.headers.get('content-security-policy') ?? '';
+    assert.match(csp, /form-action 'self' https:\/\/worker\.example/);
+    assert.doesNotMatch(csp, /cursor:/);
+    assert.doesNotMatch(csp, /\bnull\b/);
+  });
+
   it('preserves multiple Set-Cookie headers passed into HTML responses', () => {
     const extraHeaders = new Headers();
     extraHeaders.append('Set-Cookie', 'first=value-1; Path=/; HttpOnly');


### PR DESCRIPTION
## Summary
- Post OAuth approval to `/oauth/approve` without query-string form actions so CSP `form-action` no longer blocks the submit.
- Always allow the worker origin in `form-action` and ignore opaque/custom-scheme redirect URIs (for example `cursor://`).
- Add unit coverage for Cursor redirect clients.

## Test plan
- [x] `test/unit/test-worker-auth-handoff-routes.ts`
- [x] `test/unit/test-worker-response-runtime.ts`
- [ ] After deploy: approve OAuth flow from Cursor MCP and confirm redirect completes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hosted OAuth HTML/CSP changes that fix submit blocking and narrow form-action to http(s) origins; no change to token or session validation logic.
> 
> **Overview**
> Fixes hosted OAuth approval so the browser can submit the approve form under **Content-Security-Policy** instead of being blocked (notably for **Cursor MCP** clients).
> 
> The approval form now posts to **`/oauth/approve`** without query parameters on `action`; `return_to` remains in a hidden field. CSP **`form-action`** always allows the worker origin and only adds extra origins for **http/https** redirect URIs—**opaque** values and **custom schemes** (e.g. `cursor://`) are dropped when building the directive. **`normalizeFormActionOrigins`** is exported and tightened to ignore invalid schemes and `null`. Unit tests cover the new form action, CSP output, and a Cursor-style redirect URI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb7530a1bfc1093274cc26e7f97631e37a7a407. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->