### PR TITLE
fix: hosted auth CSP allows approve form submit in Chrome/Cursor

### DIFF
--- a/src/server/worker-auth-handoff-routes.ts
+++ b/src/server/worker-auth-handoff-routes.ts
@@ -31,6 +31,11 @@ import {
   type HtmlResponseSecurityOptions,
 } from './worker-response-runtime.js';
 
+const HOSTED_AUTH_HTML_SECURITY: HtmlResponseSecurityOptions = {
+  omitFormAction: true,
+  allowHostedAuthInlineScriptHashes: true,
+};
+
 const AUTH_STATE_COOKIE_NAME = 'clauth_state';
 const AUTH_APPROVAL_COOKIE_NAME = 'clauth_approve';
 const AUTH_FLOW_COOKIE_NAME = 'clauth_flow';
@@ -2053,16 +2058,6 @@ async function buildApprovalPageResponse<
     headers.append('Set-Cookie', csrfCookieHeader);
   }
   const nonce = deps.generateCspNonce();
-  const workerOrigin = new URL(request.url).origin;
-  const formActionOrigins = [workerOrigin];
-  if (
-    redirectUri &&
-    (redirectUri.protocol === 'http:' || redirectUri.protocol === 'https:') &&
-    redirectUri.origin !== 'null' &&
-    redirectUri.origin !== workerOrigin
-  ) {
-    formActionOrigins.push(redirectUri.origin);
-  }
 
   return deps.htmlResponse(
     renderAuthApprovalPage({
@@ -2077,7 +2072,7 @@ async function buildApprovalPageResponse<
     }),
     nonce,
     headers,
-    { formActionOrigins },
+    HOSTED_AUTH_HTML_SECURITY,
   );
 }
 
@@ -2390,6 +2385,7 @@ export async function handleWorkerAuthHandoffRoutes<
       }),
       nonce,
       headers,
+      HOSTED_AUTH_HTML_SECURITY,
     );
     const signal = withHostedAuthRequestDuration(
       {
@@ -2504,6 +2500,8 @@ export async function handleWorkerAuthHandoffRoutes<
           nonce,
         ),
         nonce,
+        undefined,
+        HOSTED_AUTH_HTML_SECURITY,
       );
       const signal = withHostedAuthRequestDuration(
         {
@@ -2546,6 +2544,8 @@ export async function handleWorkerAuthHandoffRoutes<
           nonce,
         ),
         nonce,
+        undefined,
+        HOSTED_AUTH_HTML_SECURITY,
       );
       const signal = withHostedAuthRequestDuration(
         {
@@ -2646,6 +2646,8 @@ export async function handleWorkerAuthHandoffRoutes<
           hasExplicitReturnTarget: resolvedReturnTo.isExplicit,
         }),
         nonce,
+        undefined,
+        HOSTED_AUTH_HTML_SECURITY,
       );
       return attachHostedAuthHeaders(
         response,
@@ -2746,6 +2748,8 @@ export async function handleWorkerAuthHandoffRoutes<
           nonce,
         ),
         nonce,
+        undefined,
+        HOSTED_AUTH_HTML_SECURITY,
       );
       const signal = withHostedAuthRequestDuration(
         {
@@ -3068,6 +3072,8 @@ export async function handleWorkerAuthHandoffRoutes<
           nonce,
         ),
         nonce,
+        undefined,
+        HOSTED_AUTH_HTML_SECURITY,
       );
       if (approveCorrelation.setCookieHeader) {
         response.headers.append('Set-Cookie', approveCorrelation.setCookieHeader);
@@ -3226,6 +3232,8 @@ export async function handleWorkerAuthHandoffRoutes<
           nonce,
         ),
         nonce,
+        undefined,
+        HOSTED_AUTH_HTML_SECURITY,
       );
       if (approveCorrelation.setCookieHeader) {
         response.headers.append('Set-Cookie', approveCorrelation.setCookieHeader);

--- a/src/server/worker-response-runtime.ts
+++ b/src/server/worker-response-runtime.ts
@@ -146,7 +146,7 @@ function appendHeaders(headers: Headers, extraHeaders?: HeadersInit): void {
 function createSecureResponseHeaders(
   baseHeaders: HeadersInit,
   extraHeaders?: HeadersInit,
-  securityOptions?: { nonce?: string; formActionOrigins?: string[] },
+  securityOptions?: HtmlResponseSecurityOptions & { nonce?: string },
 ): Headers {
   const headers = new Headers(baseHeaders);
   appendHeaders(headers, extraHeaders);
@@ -156,7 +156,7 @@ function createSecureResponseHeaders(
 
 function applySecurityHeaders(
   headers: Headers,
-  securityOptions?: { nonce?: string; formActionOrigins?: string[] },
+  securityOptions?: HtmlResponseSecurityOptions & { nonce?: string },
 ): void {
   headers.set('X-Content-Type-Options', 'nosniff');
   headers.set('X-Frame-Options', 'DENY');

--- a/src/server/worker-response-runtime.ts
+++ b/src/server/worker-response-runtime.ts
@@ -1,7 +1,16 @@
 import { buildMcpCorsHeaders } from './transport-boundary-headers.js';
 
+/** Inline scripts injected by Cloudflare/captive portals on hosted auth pages (hashes from browser CSP reports). */
+const HOSTED_AUTH_INLINE_SCRIPT_HASHES = [
+  "'sha256-CsRg1c/uAShTQr6MSbfT26yXsxtsm7ZpMgc41yupCOo='",
+  "'sha256-PBIIO99gDQxCFzWUcG6igjK4mjItQrNaA+ccPy87s0M='",
+] as const;
+
 export interface HtmlResponseSecurityOptions {
   formActionOrigins?: string[];
+  /** Hosted auth pages use same-origin POST forms; omit form-action to avoid Chrome/Cursor CSP false blocks. */
+  omitFormAction?: boolean;
+  allowHostedAuthInlineScriptHashes?: boolean;
 }
 
 export function cloneHeadersPreservingSetCookie(source: Headers): Headers {
@@ -155,26 +164,32 @@ function applySecurityHeaders(
   headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
   headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
   const nonce = securityOptions?.nonce;
+  const hostedAuthScriptHashes =
+    securityOptions?.allowHostedAuthInlineScriptHashes === true
+      ? ` ${HOSTED_AUTH_INLINE_SCRIPT_HASHES.join(' ')}`
+      : '';
   const scriptDirective = nonce
-    ? `script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com`
+    ? `script-src 'self' 'nonce-${nonce}' https://challenges.cloudflare.com${hostedAuthScriptHashes}`
     : "script-src 'none'";
   const styleDirective = nonce ? `style-src 'self' 'nonce-${nonce}'` : "style-src 'none'";
   const formActionOrigins = normalizeFormActionOrigins(securityOptions?.formActionOrigins ?? []);
-  headers.set(
-    'Content-Security-Policy',
-    [
-      "default-src 'self'",
-      "base-uri 'none'",
-      "object-src 'none'",
-      "frame-ancestors 'none'",
-      "img-src 'self' data:",
-      scriptDirective,
-      styleDirective,
-      "connect-src 'self'",
-      'frame-src https://challenges.cloudflare.com',
+  const directives = [
+    "default-src 'self'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "img-src 'self' data:",
+    scriptDirective,
+    styleDirective,
+    "connect-src 'self'",
+    'frame-src https://challenges.cloudflare.com',
+  ];
+  if (securityOptions?.omitFormAction !== true) {
+    directives.push(
       `form-action 'self'${formActionOrigins.length > 0 ? ` ${formActionOrigins.join(' ')}` : ''}`,
-    ].join('; '),
-  );
+    );
+  }
+  headers.set('Content-Security-Policy', directives.join('; '));
 }
 
 export function normalizeFormActionOrigins(origins: string[]): string[] {

--- a/test/unit/test-worker-auth-handoff-routes.ts
+++ b/test/unit/test-worker-auth-handoff-routes.ts
@@ -833,10 +833,9 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     assert.ok(responseCookies.some((cookie) => cookie.startsWith('clauth_approve=')));
     assert.ok(responseCookies.some((cookie) => cookie.startsWith('clauth_flow=')));
     assert.ok(responseCookies.some((cookie) => cookie.startsWith('clmcp_csrf=csrf-token-123')));
-    assert.match(
-      getResponse.headers.get('content-security-policy') ?? '',
-      /form-action 'self' https:\/\/worker\.example https:\/\/chatgpt\.com/,
-    );
+    const approvalCsp = getResponse.headers.get('content-security-policy') ?? '';
+    assert.doesNotMatch(approvalCsp, /form-action/);
+    assert.match(approvalCsp, /sha256-CsRg1c\/uAShTQr6MSbfT26yXsxtsm7ZpMgc41yupCOo=/);
     const approvalCorrelationId = getResponse.headers.get('x-hosted-auth-correlation-id');
     assert.match(String(approvalCorrelationId), /^[A-Za-z0-9_-]{8,}$/);
     assert.equal(completionCount, 0);
@@ -994,9 +993,8 @@ describe('handleWorkerAuthHandoffRoutes', () => {
     assert.match(cursorApprovalHtml, /action="\/oauth\/approve"/);
     assert.match(cursorApprovalHtml, /anysphere\.cursor-mcp/);
     const cursorCsp = cursorApprovalResponse.headers.get('content-security-policy') ?? '';
-    assert.match(cursorCsp, /form-action 'self' https:\/\/worker\.example/);
+    assert.doesNotMatch(cursorCsp, /form-action/);
     assert.doesNotMatch(cursorCsp, /cursor:/);
-    assert.doesNotMatch(cursorCsp, /\bnull\b/);
 
     completionCount = 0;
     const returnToParam = new URL(approvalUrl).searchParams.get('return_to');

--- a/test/unit/test-worker-response-runtime.ts
+++ b/test/unit/test-worker-response-runtime.ts
@@ -69,6 +69,17 @@ describe('worker response runtime', () => {
     );
   });
 
+  it('omits form-action when requested for hosted auth HTML', () => {
+    const response = htmlResponse('<html></html>', 'nonce', undefined, {
+      omitFormAction: true,
+      allowHostedAuthInlineScriptHashes: true,
+    });
+
+    const csp = response.headers.get('content-security-policy') ?? '';
+    assert.doesNotMatch(csp, /form-action/);
+    assert.match(csp, /sha256-CsRg1c\/uAShTQr6MSbfT26yXsxtsm7ZpMgc41yupCOo=/);
+  });
+
   it('ignores opaque and custom-scheme origins in HTML form-action CSP', () => {
     const response = htmlResponse('<html></html>', 'nonce', undefined, {
       formActionOrigins: [


### PR DESCRIPTION
## Summary
- Removes `form-action` from CSP on hosted auth HTML so Chrome/Cursor no longer blocks the same-origin `/oauth/approve` POST (regression from listing the worker origin explicitly).
- Adds known Cloudflare inline script hashes to `script-src` on auth pages.

Production Worker already deployed (version `0bddde49-efed-4ea3-b764-6eae7cfdfe68`).

## Test plan
- [x] Unit tests
- [ ] Hard-refresh OAuth approve page in Cursor and click **Approve and continue**


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes CSP on hosted auth HTML (no form-action, extra script hashes) to fix a production sign-in regression; scope is limited to those pages with tests updated.
> 
> **Overview**
> Fixes hosted OAuth browser pages where **Chrome/Cursor** blocked same-origin **Approve and continue** POSTs after CSP listed explicit `form-action` origins (including the worker).
> 
> All hosted auth HTML now uses a shared **`HOSTED_AUTH_HTML_SECURITY`** profile: **`form-action` is omitted** (same-origin forms only) and **`script-src`** allows two known **Cloudflare/captive-portal** inline script hashes from browser CSP reports. Per-page `formActionOrigins` wiring on the approval page was removed.
> 
> **`worker-response-runtime`** gains `omitFormAction` and `allowHostedAuthInlineScriptHashes`; other HTML can still set `form-action` via `formActionOrigins`. Unit tests assert approval/Cursor CSP has no `form-action` and includes the script hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50bd730e611188aa0b170bec120c7049d76d174. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->