### PR TITLE
fix: enrich smart_search citation counts from cluster detail

### DIFF
--- a/src/domains/enhanced/smart-search.ts
+++ b/src/domains/enhanced/smart-search.ts
@@ -29,6 +29,39 @@ type SearchOpinionResult = OpinionCluster & {
   url?: string;
 };
 
+function hasCitationCount(result: SearchOpinionResult): boolean {
+  const count = result.citation_count ?? result.citationCount;
+  return count !== undefined && count !== null;
+}
+
+async function enrichSmartSearchResults(
+  api: CourtListenerAPI,
+  results: SearchOpinionResult[],
+): Promise<SearchOpinionResult[]> {
+  const enriched = [...results];
+  await Promise.all(
+    results.map(async (result, index) => {
+      if (hasCitationCount(result) || typeof result.id !== 'number') {
+        return;
+      }
+      try {
+        const cluster = await api.getOpinionCluster(result.id);
+        enriched[index] = {
+          ...result,
+          citation_count: cluster.citation_count,
+          absolute_url: result.absolute_url || cluster.absolute_url,
+          case_name: result.case_name || cluster.case_name,
+          date_filed: result.date_filed || cluster.date_filed,
+          court: result.court || cluster.court,
+        };
+      } catch {
+        // Keep search payload when cluster detail is unavailable.
+      }
+    }),
+  );
+  return enriched;
+}
+
 function formatSmartSearchOpinionLine(result: SearchOpinionResult): string {
   const caseName =
     result.case_name || result.caseName || result.case_name_short || result.name || 'Untitled';
@@ -149,7 +182,10 @@ export class SmartSearchHandler extends TypedToolHandler<typeof smartSearchSchem
     if (searchParams.precedential_status) apiParams.status = searchParams.precedential_status;
 
     const results = await this.api.searchOpinions(apiParams);
-    const limitedResults = results.results.slice(0, args.max_results);
+    const limitedResults = await enrichSmartSearchResults(
+      this.api,
+      results.results.slice(0, args.max_results) as SearchOpinionResult[],
+    );
 
     return {
       content: [

--- a/test/unit/test-enhanced-handlers.ts
+++ b/test/unit/test-enhanced-handlers.ts
@@ -1056,6 +1056,51 @@ describe('SmartSearchHandler', () => {
     assert.ok(!text.includes('undefined'));
   });
 
+  it('enriches citation count from cluster detail when search omits it', async () => {
+    const mockApi = {
+      searchOpinions: async () => ({
+        count: 1,
+        results: [
+          {
+            id: 108713,
+            caseName: 'Roe v. Wade',
+            dateFiled: '1973-01-22',
+            court_id: 'scotus',
+            absolute_url: '/opinion/108713/roe-v-wade/',
+          },
+        ],
+      }),
+      getOpinionCluster: async (clusterId: number) => ({
+        id: clusterId,
+        case_name: 'Roe v. Wade',
+        citation_count: 5580,
+        absolute_url: '/opinion/108713/roe-v-wade/',
+        court: 'scotus',
+        date_filed: '1973-01-22',
+      }),
+    } as any;
+
+    const handler = new SmartSearchHandler(mockApi);
+    const result = await handler.execute(
+      { query: 'Roe v Wade', max_results: 1 },
+      {
+        ...mockContext,
+        llmParamGenerator: {
+          createMessage: async () => ({
+            content: {
+              type: 'text',
+              text: JSON.stringify({ q: 'Roe v Wade', type: 'o' }),
+            },
+          }),
+        },
+      },
+    );
+
+    const text = result.content[0].text;
+    assert.ok(text.includes('5580 cites'));
+    assert.ok(!text.includes('Citation count unavailable'));
+  });
+
   it('limits results to max_results', async () => {
     const mockApi = {
       searchOpinions: async () => ({


### PR DESCRIPTION
## Summary
- When CourtListener search results omit `citation_count` / `citationCount`, fetches cluster detail by `id` in parallel before formatting output.

## Test plan
- [x] Unit test: search without cite count + `getOpinionCluster` returns formatted `N cites`
- [ ] CI green
- [ ] Promote to main + deploy

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded extra CourtListener reads (up to max_results) with try/catch fallback; no auth or data-model changes.
> 
> **Overview**
> **Smart search** now backfills missing citation counts (and sparse metadata) from CourtListener **cluster detail** before formatting results.
> 
> After opinion search, `enrichSmartSearchResults` runs in parallel on the top `max_results` rows: rows that already have `citation_count` / `citationCount` or lack a numeric `id` are skipped; others call `getOpinionCluster` and merge `citation_count` plus optional `absolute_url`, `case_name`, `date_filed`, and `court`. Failures leave the original search row unchanged.
> 
> A unit test covers search payloads without cite counts and asserts formatted output shows `N cites` instead of "Citation count unavailable".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41f4a74045e4aec2cd2f71312fdf011167fa9cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->