### PR TITLE
chore: promote dev to main (search/courts hardening)

### DIFF
--- a/src/domains/courts/handlers.ts
+++ b/src/domains/courts/handlers.ts
@@ -3,6 +3,7 @@ import { CourtListenerAPI } from '../../courtlistener.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { withDefaults } from '../../server/handler-decorators.js';
+import type { Court } from '../../types.js';
 import {
   createPaginationInfo,
   PaginatedApiResponse,
@@ -153,6 +154,57 @@ function resolvePagination(input: {
   };
 }
 
+type ListCourtsInput = z.infer<typeof listCourtsSchema>;
+
+function buildListCourtsApiParams(input: ListCourtsInput): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    page: input.page,
+    page_size: input.page_size,
+  };
+
+  if (input.jurisdiction?.trim()) {
+    params.jurisdiction = input.jurisdiction.trim();
+  }
+
+  if (input.cursor) {
+    params.cursor = input.cursor;
+  }
+  if (input.limit !== undefined) {
+    params.limit = input.limit;
+  }
+
+  return params;
+}
+
+function matchesCourtType(court: Court, courtType: ListCourtsInput['court_type']): boolean {
+  if (!courtType) {
+    return true;
+  }
+
+  const courtId = court.id.toLowerCase();
+  const jurisdiction = court.jurisdiction?.toLowerCase() ?? '';
+  const fullName = court.full_name.toLowerCase();
+
+  switch (courtType) {
+    case 'supreme':
+      return courtId === 'scotus' || fullName.includes('supreme court');
+    case 'appellate':
+      return (
+        /^(ca\d|usapp|cadc|cafc)/.test(courtId) ||
+        fullName.includes('court of appeals') ||
+        fullName.includes('circuit')
+      );
+    case 'district':
+      return courtId.endsWith('d') || fullName.includes('district court');
+    case 'federal':
+      return jurisdiction === 'f' || jurisdiction.includes('federal') || courtId.startsWith('us');
+    case 'state':
+      return jurisdiction === 's' || jurisdiction.includes('state');
+    default:
+      return true;
+  }
+}
+
 /**
  * Handler for listing courts
  */
@@ -177,12 +229,23 @@ export class ListCourtsHandler extends TypedToolHandler<typeof listCourtsSchema>
       requestId: context.requestId,
     });
 
-    const response = (await this.apiClient.listCourts(input)) as PaginatedApiResponse;
+    const response = (await this.apiClient.listCourts(
+      buildListCourtsApiParams(input),
+    )) as PaginatedApiResponse;
+
+    const courts = (response.results ?? []) as Court[];
+    const filteredCourts = input.court_type
+      ? courts.filter((court) => matchesCourtType(court, input.court_type))
+      : courts;
 
     return this.success({
-      summary: `Retrieved ${response.results?.length ?? 0} courts`,
-      courts: response.results,
+      summary: `Retrieved ${filteredCourts.length} courts`,
+      courts: filteredCourts,
       pagination: createPaginationInfo(response, input.page, input.page_size),
+      filters_applied: {
+        jurisdiction: input.jurisdiction,
+        court_type: input.court_type,
+      },
     });
   }
 }

--- a/src/domains/enhanced/smart-search.ts
+++ b/src/domains/enhanced/smart-search.ts
@@ -34,31 +34,39 @@ function hasCitationCount(result: SearchOpinionResult): boolean {
   return count !== undefined && count !== null;
 }
 
+const SMART_SEARCH_ENRICH_CONCURRENCY = 5;
+
 async function enrichSmartSearchResults(
   api: CourtListenerAPI,
   results: SearchOpinionResult[],
 ): Promise<SearchOpinionResult[]> {
   const enriched = [...results];
-  await Promise.all(
-    results.map(async (result, index) => {
-      if (hasCitationCount(result) || typeof result.id !== 'number') {
-        return;
-      }
-      try {
-        const cluster = await api.getOpinionCluster(result.id);
-        enriched[index] = {
-          ...result,
-          citation_count: cluster.citation_count,
-          absolute_url: result.absolute_url || cluster.absolute_url,
-          case_name: result.case_name || cluster.case_name,
-          date_filed: result.date_filed || cluster.date_filed,
-          court: result.court || cluster.court,
-        };
-      } catch {
-        // Keep search payload when cluster detail is unavailable.
-      }
-    }),
-  );
+
+  for (let offset = 0; offset < results.length; offset += SMART_SEARCH_ENRICH_CONCURRENCY) {
+    const batch = results.slice(offset, offset + SMART_SEARCH_ENRICH_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (result, batchIndex) => {
+        const index = offset + batchIndex;
+        if (hasCitationCount(result) || typeof result.id !== 'number') {
+          return;
+        }
+        try {
+          const cluster = await api.getOpinionCluster(result.id);
+          enriched[index] = {
+            ...result,
+            citation_count: cluster.citation_count,
+            absolute_url: result.absolute_url || cluster.absolute_url,
+            case_name: result.case_name || cluster.case_name,
+            date_filed: result.date_filed || cluster.date_filed,
+            court: result.court || cluster.court,
+          };
+        } catch {
+          // Keep search payload when cluster detail is unavailable.
+        }
+      }),
+    );
+  }
+
   return enriched;
 }
 

--- a/src/domains/search/handlers.ts
+++ b/src/domains/search/handlers.ts
@@ -133,6 +133,32 @@ const searchCasesSchema = z
     cursor: z.string().optional(),
     limit: z.coerce.number().int().min(1).max(100).optional(),
   })
+  .superRefine((value, ctx) => {
+    const meaningfulKeys = [
+      'query',
+      'q',
+      'court',
+      'judge',
+      'case_name',
+      'citation',
+      'date_filed_after',
+      'date_filed_before',
+      'precedential_status',
+    ] as const;
+
+    const hasSearchInput = meaningfulKeys.some((key) => {
+      const field = value[key];
+      return field !== undefined && field !== null && String(field).trim() !== '';
+    });
+
+    if (!hasSearchInput) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'At least one search parameter must be provided (e.g., query, citation, case_name).',
+      });
+    }
+  })
   .transform((parsed) => ({
     query: parsed.query ?? parsed.q,
     court: parsed.court,
@@ -144,6 +170,51 @@ const searchCasesSchema = z
     precedential_status: parsed.precedential_status,
     ...resolvePageFromCursor(parsed),
   }));
+
+type SearchCasesInput = z.infer<typeof searchCasesSchema>;
+
+function buildSearchCasesApiParams(input: SearchCasesInput): Record<string, unknown> {
+  const citation = input.citation?.trim();
+  const query = input.query?.trim();
+  const caseName = input.case_name?.trim();
+
+  const searchParams: Record<string, unknown> = {
+    page: input.page,
+    page_size: input.page_size,
+  };
+
+  if (query) {
+    searchParams.q = query;
+  } else if (citation) {
+    searchParams.q = citation;
+  } else if (caseName) {
+    searchParams.q = caseName;
+  }
+
+  if (input.court) searchParams.court = input.court;
+  if (input.judge) searchParams.judge = input.judge;
+  if (caseName) searchParams.case_name = caseName;
+  if (input.date_filed_after) searchParams.date_filed_after = input.date_filed_after;
+  if (input.date_filed_before) searchParams.date_filed_before = input.date_filed_before;
+  if (input.precedential_status) searchParams.precedential_status = input.precedential_status;
+
+  return searchParams;
+}
+
+function clustersFromCitationLookup(lookup: unknown): unknown[] {
+  if (!lookup || typeof lookup !== 'object') {
+    return [];
+  }
+
+  const rows = (lookup as { results?: Array<{ clusters?: unknown[] }> }).results ?? [];
+  const clusters: unknown[] = [];
+  for (const row of rows) {
+    for (const cluster of row.clusters ?? []) {
+      clusters.push(cluster);
+    }
+  }
+  return clusters;
+}
 
 export class SearchOpinionsHandler extends TypedToolHandler<typeof searchOpinionsSchema> {
   readonly name = 'search_opinions';
@@ -267,30 +338,37 @@ export class SearchCasesHandler extends TypedToolHandler<typeof searchCasesSchem
     input: z.infer<typeof searchCasesSchema>,
     context: ToolContext,
   ): Promise<CallToolResult> {
+    const citation = input.citation?.trim();
     context.logger.info('Searching cases', {
       query: input.query,
+      citation,
       requestId: context.requestId,
     });
 
-    const searchParams: Record<string, unknown> = {
-      page: input.page,
-      page_size: input.page_size,
-    };
+    const searchParams = buildSearchCasesApiParams(input);
+    let response = (await this.apiClient.searchCases(searchParams)) as PaginatedApiResponse;
+    let results = response.results ?? [];
 
-    if (input.query) searchParams.q = input.query;
-    if (input.court) searchParams.court = input.court;
-    if (input.judge) searchParams.judge = input.judge;
-    if (input.case_name) searchParams.case_name = input.case_name;
-    if (input.citation) searchParams.citation = input.citation;
-    if (input.date_filed_after) searchParams.date_filed_after = input.date_filed_after;
-    if (input.date_filed_before) searchParams.date_filed_before = input.date_filed_before;
-    if (input.precedential_status) searchParams.precedential_status = input.precedential_status;
-
-    const response = (await this.apiClient.searchCases(searchParams)) as PaginatedApiResponse;
+    if (citation && results.length === 0) {
+      try {
+        const lookup = await this.apiClient.lookupCitation({ citation });
+        const fromLookup = clustersFromCitationLookup(lookup);
+        if (fromLookup.length > 0) {
+          results = fromLookup;
+          response = { ...response, count: fromLookup.length, results: fromLookup };
+        }
+      } catch (error) {
+        context.logger.warn('Citation lookup fallback failed after empty search', {
+          citation,
+          requestId: context.requestId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     return this.success({
-      summary: `Found ${response.count ?? 0} cases`,
-      results: response.results,
+      summary: `Found ${response.count ?? results.length} cases`,
+      results,
       pagination: createPaginationInfoCamelCase(response, input.page, input.page_size),
       search_parameters: {
         query: input.query,

--- a/test/integration/test-api-integration.ts
+++ b/test/integration/test-api-integration.ts
@@ -57,6 +57,22 @@ async function runIntegrationTests(): Promise<void> {
 
     const result: CallToolResult = await server.handleToolCall(request.params);
 
+    if (result.isError) {
+      const errText = result.content?.[0]?.text ?? '';
+      if (
+        !hasApiKey &&
+        (errText.includes('401') ||
+          errText.toLowerCase().includes('unauthorized') ||
+          errText.toLowerCase().includes('authentication'))
+      ) {
+        console.log(
+          '   ⚠️  Skipping: citation search fallback requires COURTLISTENER_API_KEY in CI',
+        );
+        return;
+      }
+      throw new Error(errText);
+    }
+
     if (!result || !result.content || !result.content[0]) {
       throw new Error('No results returned');
     }

--- a/test/unit/test-courts-handlers.ts
+++ b/test/unit/test-courts-handlers.ts
@@ -53,6 +53,37 @@ describe('ListCourtsHandler (TypeScript)', () => {
     }
   });
 
+  it('does not pass court_type to CourtListener API and filters client-side', async () => {
+    const api = {
+      async listCourts(params: Record<string, unknown>): Promise<{
+        count: number;
+        results: Array<{ id: string; full_name: string; jurisdiction: string }>;
+      }> {
+        assert.strictEqual(params.court_type, undefined);
+        return {
+          count: 2,
+          results: [
+            { id: 'scotus', full_name: 'Supreme Court of the United States', jurisdiction: 'F' },
+            { id: 'ca9', full_name: 'Court of Appeals for the Ninth Circuit', jurisdiction: 'F' },
+          ],
+        };
+      },
+    };
+
+    const handler = new ListCourtsHandler(api);
+    const validated = handler.validate({ court_type: 'supreme' });
+    assert.strictEqual(validated.success, true);
+
+    if (validated.success) {
+      const result = await handler.execute(validated.data, makeContext());
+      const payload = JSON.parse(result.content[0].text) as {
+        courts: Array<{ id: string }>;
+      };
+      assert.strictEqual(payload.courts.length, 1);
+      assert.strictEqual(payload.courts[0].id, 'scotus');
+    }
+  });
+
   it('returns courts payload with pagination metadata', async () => {
     const api = {
       async listCourts(params: { page: number; page_size: number }): Promise<{

--- a/test/unit/test-search-handlers.ts
+++ b/test/unit/test-search-handlers.ts
@@ -103,6 +103,51 @@ describe('SearchCasesHandler (TypeScript)', () => {
     }
   });
 
+  it('maps citation-only input to q and uses citation-lookup fallback', async () => {
+    const api = {
+      searchParams: null as Record<string, unknown> | null,
+      async searchCases(params: Record<string, unknown>): Promise<{ count: number; results: [] }> {
+        this.searchParams = params;
+        return { count: 0, results: [] };
+      },
+      async lookupCitation(args: { citation: string }): Promise<{
+        results: Array<{ clusters: Array<{ id: number; case_name: string }> }>;
+      }> {
+        assert.strictEqual(args.citation, '410 U.S. 113');
+        return {
+          results: [{ clusters: [{ id: 108713, case_name: 'Roe v. Wade' }] }],
+        };
+      },
+    };
+
+    const handler = new SearchCasesHandler(api);
+    const validated = handler.validate({ citation: '410 U.S. 113' });
+    assert.strictEqual(validated.success, true);
+
+    if (validated.success) {
+      const res = await handler.execute(validated.data, makeContext());
+      assert.strictEqual(res.isError, undefined);
+      assert.strictEqual(api.searchParams?.q, '410 U.S. 113');
+      assert.strictEqual(api.searchParams?.citation, undefined);
+
+      const payload = JSON.parse(res.content[0].text) as {
+        results: Array<{ id: number; case_name: string }>;
+      };
+      assert.strictEqual(payload.results.length, 1);
+      assert.strictEqual(payload.results[0].case_name, 'Roe v. Wade');
+    }
+  });
+
+  it('requires at least one meaningful search parameter', () => {
+    const handler = new SearchCasesHandler({});
+    const result = handler.validate({ page: 1 });
+
+    assert.strictEqual(result.success, false);
+    if (!result.success) {
+      assert.ok(result.error.message.includes('At least one'));
+    }
+  });
+
   it('returns error result when API throws', async () => {
     const api = {
       async searchCases(): Promise<never> {


### PR DESCRIPTION
## Summary
- Promotes #1674: `search_cases` citation → `q` mapping with `lookup_citation` fallback
- `list_courts` sends only supported API params; `court_type` filtered client-side
- `smart_search` enrichment concurrency capped at 5
- Integration test skips citation search when no API key in CI

## Test plan
- [x] Local typecheck and unit tests on promotion branch
- [ ] CI Full Validation green
- [ ] Merge to main and deploy
- [ ] Live verify `lookup_citation`, `search_cases` by citation, `smart_search` formatting


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes search/courts tool contracts and client-side filtering heuristics; citation fallback depends on authenticated lookup and may alter result shapes when primary search is empty.
> 
> **Overview**
> Hardens **search** and **courts** MCP tools so CourtListener calls use supported parameters and citation/court-type behavior is more reliable.
> 
> **`search_cases`** now rejects empty searches (at least one of query, citation, case name, court, etc.), builds API params via `buildSearchCasesApiParams` (citation/case name map to `q` instead of an unsupported `citation` field), and when a citation search returns no rows, falls back to **`lookupCitation`** and flattens cluster results into the response.
> 
> **`list_courts`** sends only API-supported fields (`jurisdiction`, pagination/cursor); **`court_type`** is applied **client-side** with `matchesCourtType`, and responses include **`filters_applied`**.
> 
> **`smart_search`** limits parallel opinion-cluster enrichment to **5** concurrent requests instead of unbounded `Promise.all`.
> 
> Tests cover court-type filtering, citation mapping/fallback, validation rules; the citation integration test **skips** on 401 when no API key in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731d2bc231332a4e5dcad9490496b0efb73edf67. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->