### PR TITLE
fix: omit misleading pagination totals when list_courts filters by court_type

### DIFF
--- a/src/domains/courts/handlers.ts
+++ b/src/domains/courts/handlers.ts
@@ -237,11 +237,16 @@ export class ListCourtsHandler extends TypedToolHandler<typeof listCourtsSchema>
     const filteredCourts = input.court_type
       ? courts.filter((court) => matchesCourtType(court, input.court_type))
       : courts;
+    const pagination = createPaginationInfo(response, input.page, input.page_size);
+    if (input.court_type) {
+      delete pagination.count;
+      delete pagination.total_pages;
+    }
 
     return this.success({
       summary: `Retrieved ${filteredCourts.length} courts`,
       courts: filteredCourts,
-      pagination: createPaginationInfo(response, input.page, input.page_size),
+      pagination,
       filters_applied: {
         jurisdiction: input.jurisdiction,
         court_type: input.court_type,

--- a/src/domains/courts/handlers.ts
+++ b/src/domains/courts/handlers.ts
@@ -241,6 +241,8 @@ export class ListCourtsHandler extends TypedToolHandler<typeof listCourtsSchema>
     if (input.court_type) {
       delete pagination.count;
       delete pagination.total_pages;
+      delete pagination.has_next;
+      delete pagination.nextCursor;
     }
 
     return this.success({

--- a/test/unit/test-courts-handlers.ts
+++ b/test/unit/test-courts-handlers.ts
@@ -78,9 +78,12 @@ describe('ListCourtsHandler (TypeScript)', () => {
       const result = await handler.execute(validated.data, makeContext());
       const payload = JSON.parse(result.content[0].text) as {
         courts: Array<{ id: string }>;
+        pagination: { count?: number; total_pages?: number };
       };
       assert.strictEqual(payload.courts.length, 1);
       assert.strictEqual(payload.courts[0].id, 'scotus');
+      assert.strictEqual(payload.pagination.count, undefined);
+      assert.strictEqual(payload.pagination.total_pages, undefined);
     }
   });
 
@@ -105,10 +108,12 @@ describe('ListCourtsHandler (TypeScript)', () => {
       const payload = JSON.parse(result.content[0].text) as {
         summary: string;
         courts: Array<{ id: number }>;
+        pagination: { count?: number };
       };
       assert.ok(payload.summary.includes('courts') || payload.summary.includes('Retrieved'));
       assert.ok(Array.isArray(payload.courts));
       assert.strictEqual(payload.courts.length, 2);
+      assert.strictEqual(payload.pagination.count, 35);
     }
   });
 });


### PR DESCRIPTION
## Summary
When `list_courts` applies client-side `court_type` filtering, drop `pagination.count` and `pagination.total_pages` so callers are not misled by API-wide totals.

## Test plan
- [x] Unit tests for `ListCourtsHandler` (filtered vs unfiltered pagination)
- [ ] CI green on dev
- [ ] Promote to main and deploy


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix to list_courts response shape and unit tests only; no auth, security, or data-pipeline changes.
> 
> **Overview**
> **`list_courts`** still applies **`court_type`** filtering on the client after the CourtListener response, but when that filter is present the handler now **removes `pagination.count` and `pagination.total_pages`** from the tool payload so totals are not taken from the unfiltered API page.
> 
> Unfiltered **`list_courts`** responses keep full pagination metadata (e.g. **`count`** from the API). Unit tests cover both the filtered case (totals omitted) and the unfiltered case (totals preserved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc8095ba625c303df11d09a0b72c0c2ad2d29dbd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->