### PR TITLE
chore: promote dev to main (list_courts pagination metadata)

### DIFF
--- a/src/domains/courts/handlers.ts
+++ b/src/domains/courts/handlers.ts
@@ -237,11 +237,18 @@ export class ListCourtsHandler extends TypedToolHandler<typeof listCourtsSchema>
     const filteredCourts = input.court_type
       ? courts.filter((court) => matchesCourtType(court, input.court_type))
       : courts;
+    const pagination = createPaginationInfo(response, input.page, input.page_size);
+    if (input.court_type) {
+      delete pagination.count;
+      delete pagination.total_pages;
+      delete pagination.has_next;
+      delete pagination.nextCursor;
+    }
 
     return this.success({
       summary: `Retrieved ${filteredCourts.length} courts`,
       courts: filteredCourts,
-      pagination: createPaginationInfo(response, input.page, input.page_size),
+      pagination,
       filters_applied: {
         jurisdiction: input.jurisdiction,
         court_type: input.court_type,

--- a/test/unit/test-courts-handlers.ts
+++ b/test/unit/test-courts-handlers.ts
@@ -78,9 +78,12 @@ describe('ListCourtsHandler (TypeScript)', () => {
       const result = await handler.execute(validated.data, makeContext());
       const payload = JSON.parse(result.content[0].text) as {
         courts: Array<{ id: string }>;
+        pagination: { count?: number; total_pages?: number };
       };
       assert.strictEqual(payload.courts.length, 1);
       assert.strictEqual(payload.courts[0].id, 'scotus');
+      assert.strictEqual(payload.pagination.count, undefined);
+      assert.strictEqual(payload.pagination.total_pages, undefined);
     }
   });
 
@@ -105,10 +108,12 @@ describe('ListCourtsHandler (TypeScript)', () => {
       const payload = JSON.parse(result.content[0].text) as {
         summary: string;
         courts: Array<{ id: number }>;
+        pagination: { count?: number };
       };
       assert.ok(payload.summary.includes('courts') || payload.summary.includes('Retrieved'));
       assert.ok(Array.isArray(payload.courts));
       assert.strictEqual(payload.courts.length, 2);
+      assert.strictEqual(payload.pagination.count, 35);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Promotes #1676: when `list_courts` filters by `court_type` client-side, omit misleading pagination totals and next-page hints from the API response.

## Test plan
- [x] Local gate (87 unit tests)
- [ ] CI Full Validation
- [ ] Merge and deploy


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small response-shape change for one optional filter path; no auth, persistence, or security impact.
> 
> **Overview**
> When **`list_courts`** is called with a **`court_type`** filter, results are narrowed **after** the CourtListener page is fetched. The handler now **removes** pagination fields that still describe the **unfiltered** API page—**`count`**, **`total_pages`**, **`has_next`**, and **`nextCursor`**—so clients are not steered toward incorrect totals or next pages.
> 
> Unfiltered **`list_courts`** responses keep full pagination metadata from **`createPaginationInfo`**. Unit tests cover both paths: omitted totals with **`court_type`**, preserved **`count`** without it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69da596972e18abda98c9a2881f2ef939a730213. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined pagination response in court search. Pagination metadata is now appropriately excluded when filtering courts by specific type, ensuring consistent and accurate response structures based on query parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blakeox/courtlistener-mcp/pull/1677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->