### PR TITLE
fix: reduce Durable Object duration usage on MCP requests

### DIFF
--- a/docs/repo/AUTH_START_INTEGRATION.md
+++ b/docs/repo/AUTH_START_INTEGRATION.md
@@ -105,6 +105,38 @@ recognized by the Worker, but the published browser-auth contract is now the
 
 ## Troubleshooting
 
+### Durable Objects free-tier duration quota (HTTP 503 / alert email)
+
+Cloudflare bills Durable Object **duration** (CPU + storage I/O time while a DO
+is active). This repo uses two DO classes:
+
+- **`AuthFailureLimiterDO`** — auth rate limits, MCP session registry, usage
+  counters (called many times per MCP request)
+- **`CourtListenerMCP`** — one DO per connected MCP client session
+
+If you receive a “90% of daily Durable Objects free tier limit” email, check
+`/health` → `metrics.latency_ms.durable_objects.*` on the edge and MCP workers.
+
+**Immediate mitigation (no deploy):**
+
+1. Wait for the quota reset (midnight UTC).
+2. Upgrade to the **Workers Paid** plan for production traffic.
+3. Temporarily reduce DO load via env vars:
+   - `MCP_BOUNDARY_GUARDS_ENABLED=false` — removes bundled boundary/replay DO
+     calls per MCP request
+   - `MCP_AUTH_FAILURE_RATE_LIMIT_ENABLED=false` — disables auth/OAuth limiter
+     DO calls
+
+**Code-side optimizations (deploy auth-limiter + MCP workers):**
+
+- MCP session **touch** no longer runs eviction sweeps on every request (alarms
+  handle cleanup).
+- MCP boundary + replay checks are bundled into **one** DO call per request.
+- Successful MCP auth skips a redundant **clear** DO call when the client has no
+  failure state.
+
+See `docs/repo/WORKER_BUNDLE_AUDIT.md` for architecture context.
+
 ### `oauth_route_rate_limit_unavailable` (HTTP 503)
 
 ```json

--- a/src/server/auth-failure-limiter-do.ts
+++ b/src/server/auth-failure-limiter-do.ts
@@ -11,6 +11,8 @@ import type {
   BrowserBootstrapConsumeResponseBody,
   LifetimeQuotaRequestBody,
   LifetimeQuotaResponseBody,
+  McpBoundaryEvaluateRequestBody,
+  McpBoundaryEvaluateResponseBody,
   McpSessionEvictionReason,
   McpSessionLifecycleRequestBody,
   McpSessionLifecycleResponseBody,
@@ -101,6 +103,115 @@ export class AuthFailureLimiterDO {
       this.state.storage.delete(AuthFailureLimiterDO.AUTH_FAILURE_WINDOW_MS_KEY),
       this.state.storage.delete(AuthFailureLimiterDO.AUTH_FAILURE_CLEANUP_AT_MS_KEY),
     ]);
+  }
+
+  private getNamedAuthStateKey(scope: 'boundary' | 'replay', replayFingerprint?: string): string {
+    if (scope === 'boundary') {
+      return 'auth_failure_state';
+    }
+    const fingerprint = typeof replayFingerprint === 'string' ? replayFingerprint.trim() : '';
+    return fingerprint ? `mcp_replay_state:${fingerprint}` : 'mcp_replay_state:invalid';
+  }
+
+  private getNamedAuthWindowKey(scope: 'boundary' | 'replay', replayFingerprint?: string): string {
+    if (scope === 'boundary') {
+      return AuthFailureLimiterDO.AUTH_FAILURE_WINDOW_MS_KEY;
+    }
+    const fingerprint = typeof replayFingerprint === 'string' ? replayFingerprint.trim() : '';
+    return fingerprint ? `mcp_replay_window_ms:${fingerprint}` : 'mcp_replay_window_ms:invalid';
+  }
+
+  private async loadNamedAuthState(
+    scope: 'boundary' | 'replay',
+    replayFingerprint?: string,
+  ): Promise<AuthFailureState> {
+    const key = this.getNamedAuthStateKey(scope, replayFingerprint);
+    const stored = await this.state.storage.get<AuthFailureState>(key);
+    if (!stored) return { ...DEFAULT_AUTH_FAILURE_STATE };
+    return {
+      count: typeof stored.count === 'number' ? stored.count : 0,
+      windowStartedAtMs:
+        typeof stored.windowStartedAtMs === 'number' ? stored.windowStartedAtMs : 0,
+      blockedUntilMs: typeof stored.blockedUntilMs === 'number' ? stored.blockedUntilMs : 0,
+    };
+  }
+
+  private async loadNamedAuthWindowMs(
+    scope: 'boundary' | 'replay',
+    replayFingerprint?: string,
+  ): Promise<number | null> {
+    const key = this.getNamedAuthWindowKey(scope, replayFingerprint);
+    const stored = await this.state.storage.get<number>(key);
+    return typeof stored === 'number' && Number.isFinite(stored) ? stored : null;
+  }
+
+  private async saveNamedAuthState(
+    scope: 'boundary' | 'replay',
+    nextState: AuthFailureState,
+    windowMs: number,
+    replayFingerprint?: string,
+  ): Promise<void> {
+    await Promise.all([
+      this.state.storage.put(this.getNamedAuthStateKey(scope, replayFingerprint), nextState),
+      this.state.storage.put(this.getNamedAuthWindowKey(scope, replayFingerprint), windowMs),
+    ]);
+  }
+
+  private async clearNamedAuthState(
+    scope: 'boundary' | 'replay',
+    replayFingerprint?: string,
+  ): Promise<void> {
+    await Promise.all([
+      this.state.storage.delete(this.getNamedAuthStateKey(scope, replayFingerprint)),
+      this.state.storage.delete(this.getNamedAuthWindowKey(scope, replayFingerprint)),
+    ]);
+  }
+
+  private async recordNamedAuthLimit(
+    scope: 'boundary' | 'replay',
+    nowMs: number,
+    maxAttempts: number,
+    windowMs: number,
+    blockMs: number,
+    replayFingerprint?: string,
+  ): Promise<{ blocked: boolean; retryAfterSeconds: number; state: AuthFailureState }> {
+    let current = await this.loadNamedAuthState(scope, replayFingerprint);
+    const storedWindowMs = await this.loadNamedAuthWindowMs(scope, replayFingerprint);
+    const effectiveWindowMs =
+      storedWindowMs && storedWindowMs > 0 ? Math.max(1_000, storedWindowMs) : windowMs;
+    const currentCleanupAt = this.getAuthFailureCleanupAtMs(current, effectiveWindowMs);
+    if (currentCleanupAt > 0 && currentCleanupAt <= nowMs) {
+      current = { ...DEFAULT_AUTH_FAILURE_STATE };
+      await this.clearNamedAuthState(scope, replayFingerprint);
+    }
+
+    if (current.windowStartedAtMs <= 0 || nowMs - current.windowStartedAtMs >= windowMs) {
+      current = {
+        count: 0,
+        windowStartedAtMs: nowMs,
+        blockedUntilMs: 0,
+      };
+    }
+    const nextCount = current.count + 1;
+    const shouldBlock = nextCount >= maxAttempts;
+    current = {
+      count: nextCount,
+      windowStartedAtMs: current.windowStartedAtMs || nowMs,
+      blockedUntilMs: shouldBlock ? nowMs + blockMs : current.blockedUntilMs,
+    };
+    await this.saveNamedAuthState(scope, current, windowMs, replayFingerprint);
+    if (scope === 'boundary') {
+      await this.scheduleAuthFailureCleanupAlarm(this.getAuthFailureCleanupAtMs(current, windowMs));
+    }
+
+    const blocked = current.blockedUntilMs > nowMs;
+    return {
+      blocked,
+      retryAfterSeconds: blocked
+        ? Math.max(1, Math.ceil((current.blockedUntilMs - nowMs) / 1000))
+        : 0,
+      state: current,
+    };
   }
 
   private getMcpSessionStorageKey(sessionId: string): string {
@@ -204,6 +315,7 @@ export class AuthFailureLimiterDO {
       | BrowserBootstrapConsumeRequestBody
       | UsageCounterRequestBody
       | LifetimeQuotaRequestBody
+      | McpBoundaryEvaluateRequestBody
       | McpSessionLifecycleRequestBody
     >(request);
     if (!body) {
@@ -234,7 +346,10 @@ export class AuthFailureLimiterDO {
         return Response.json({ error: 'invalid_session_id' }, { status: 400 });
       }
 
-      await this.evictExpiredMcpSessions(nowMs, sweepLimit);
+      // Touch is the hot path; rely on alarms for periodic eviction sweeps.
+      if (body.action !== 'mcp_session_touch') {
+        await this.evictExpiredMcpSessions(nowMs, sweepLimit);
+      }
       const storageKey = this.getMcpSessionStorageKey(sessionId);
       const existing = await this.loadMcpSessionState(sessionId);
 
@@ -444,6 +559,57 @@ export class AuthFailureLimiterDO {
 
       await this.state.storage.put(browserBootstrapKey, next);
       return Response.json({ ok: true });
+    }
+
+    if (body.action === 'mcp_boundary_evaluate') {
+      const boundaryBody = body as McpBoundaryEvaluateRequestBody;
+      const nowMs = Number.isFinite(boundaryBody.nowMs) ? boundaryBody.nowMs : Date.now();
+      const boundary = boundaryBody.boundary;
+      const boundaryMaxAttempts = Math.max(1, boundary?.maxAttempts ?? 1);
+      const boundaryWindowMs = Math.max(1_000, boundary?.windowMs ?? 60_000);
+      const boundaryBlockMs = Math.max(1_000, boundary?.blockMs ?? 120_000);
+
+      const boundaryResult = await this.recordNamedAuthLimit(
+        'boundary',
+        nowMs,
+        boundaryMaxAttempts,
+        boundaryWindowMs,
+        boundaryBlockMs,
+      );
+      if (boundaryResult.blocked) {
+        return Response.json({
+          blocked: true,
+          retryAfterSeconds: boundaryResult.retryAfterSeconds,
+          reason: 'boundary_rate_limit',
+        } satisfies McpBoundaryEvaluateResponseBody);
+      }
+
+      const replay = boundaryBody.replay;
+      const replayFingerprint =
+        typeof replay?.fingerprint === 'string' ? replay.fingerprint.trim() : '';
+      if (replay && replayFingerprint) {
+        const replayResult = await this.recordNamedAuthLimit(
+          'replay',
+          nowMs,
+          Math.max(1, replay.maxAttempts ?? 2),
+          Math.max(1_000, replay.windowMs ?? 120_000),
+          Math.max(1_000, replay.blockMs ?? 120_000),
+          replayFingerprint,
+        );
+        if (replayResult.blocked) {
+          return Response.json({
+            blocked: true,
+            retryAfterSeconds: replayResult.retryAfterSeconds,
+            reason: 'replay_detected',
+          } satisfies McpBoundaryEvaluateResponseBody);
+        }
+      }
+
+      return Response.json({
+        blocked: false,
+        retryAfterSeconds: 0,
+        reason: null,
+      } satisfies McpBoundaryEvaluateResponseBody);
     }
 
     if (body.action === 'quota_increment_check') {

--- a/src/server/mcp-transport-runtime-facade.ts
+++ b/src/server/mcp-transport-runtime-facade.ts
@@ -8,6 +8,7 @@ import type {
   ProtocolHeaderNegotiationDiagnostics,
   WorkerSecurityEnv,
 } from './worker-security.js';
+import type { AuthRateLimitProbeResult } from './worker-runtime-contract.js';
 import { isAllowedOrigin } from './worker-security.js';
 
 export interface McpHandler<Env extends WorkerSecurityEnv> {
@@ -249,8 +250,18 @@ export interface HandleMcpTransportBoundaryParams<
     env: Env,
     nowMs: number,
   ) => Promise<Response | null>;
+  probeAuthRateLimit?: (
+    clientId: string,
+    env: Env,
+    nowMs: number,
+  ) => Promise<AuthRateLimitProbeResult>;
   recordAuthFailure: (clientId: string, env: Env, nowMs: number) => Promise<void>;
-  clearAuthFailures: (clientId: string, env: Env, nowMs: number) => Promise<void>;
+  clearAuthFailures: (
+    clientId: string,
+    env: Env,
+    nowMs: number,
+    hadFailureState?: boolean,
+  ) => Promise<void>;
   skipGatewayAuth?: boolean;
   evaluateMcpBoundaryRequest?: (
     request: Request,
@@ -292,6 +303,7 @@ export async function handleMcpTransportBoundary<
     buildCorsHeaders,
     getClientIdentifier,
     getAuthRateLimitedResponse,
+    probeAuthRateLimit,
     recordAuthFailure,
     clearAuthFailures,
     skipGatewayAuth,
@@ -346,10 +358,16 @@ export async function handleMcpTransportBoundary<
     // Standard direct-access path: validate credentials via gateway auth
     // with rate-limiting and protocol-version enforcement.
     const clientId = getClientIdentifier(request);
-    const rateLimited = await getAuthRateLimitedResponse(clientId, env, nowMs);
-    if (rateLimited) {
-      return withCors(rateLimited, origin, allowedOrigins);
+    const authRateLimitProbe = probeAuthRateLimit
+      ? await probeAuthRateLimit(clientId, env, nowMs)
+      : ({
+          kind: 'allowed',
+          hasFailureState: false,
+        } satisfies AuthRateLimitProbeResult);
+    if (authRateLimitProbe.kind !== 'allowed') {
+      return withCors(authRateLimitProbe.response, origin, allowedOrigins);
     }
+    const hadAuthFailureState = authRateLimitProbe.hasFailureState;
 
     if (evaluateMcpBoundaryRequest) {
       const abuseError = await evaluateMcpBoundaryRequest(request, env, clientId, nowMs);
@@ -379,7 +397,7 @@ export async function handleMcpTransportBoundary<
       );
     }
 
-    await clearAuthFailures(clientId, env, nowMs);
+    await clearAuthFailures(clientId, env, nowMs, hadAuthFailureState);
     principal = authResult.principal;
     protocolNegotiation = authResult.protocolNegotiation;
   }

--- a/src/server/worker-durable-runtime.ts
+++ b/src/server/worker-durable-runtime.ts
@@ -7,11 +7,14 @@ import {
 import type {
   AuthFailureLimiterRequestBody,
   AuthFailureLimiterResponseBody,
+  AuthRateLimitProbeResult,
   BrowserBootstrapConsumeRequestBody,
   BrowserBootstrapConsumeResponseBody,
   DurableObjectLatencyDimension,
   LifetimeQuotaRequestBody,
   LifetimeQuotaResponseBody,
+  McpBoundaryEvaluateRequestBody,
+  McpBoundaryEvaluateResponseBody,
   McpSessionLifecycleAction,
   McpSessionLifecycleRequestBody,
   McpSessionLifecycleResponseBody,
@@ -133,13 +136,23 @@ export interface WorkerDurableRuntime<TEnv extends WorkerDurableRuntimeEnv> {
     env: TEnv,
     nowMs: number,
   ) => Promise<Response | null>;
+  probeAuthRateLimit: (
+    clientId: string,
+    env: TEnv,
+    nowMs: number,
+  ) => Promise<AuthRateLimitProbeResult>;
   getAuthRouteRateLimitedResponse: (
     bucketId: string,
     env: TEnv,
     nowMs: number,
   ) => Promise<Response | null>;
   recordAuthFailure: (clientId: string, env: TEnv, nowMs: number) => Promise<void>;
-  clearAuthFailures: (clientId: string, env: TEnv, nowMs: number) => Promise<void>;
+  clearAuthFailures: (
+    clientId: string,
+    env: TEnv,
+    nowMs: number,
+    hadFailureState?: boolean,
+  ) => Promise<void>;
   evaluateMcpBoundaryRequest: (
     request: Request,
     env: TEnv,
@@ -332,6 +345,50 @@ async function callAuthLimiter<TEnv extends WorkerDurableRuntimeEnv>(
         message: error instanceof Error ? error.message : String(error),
       }),
     );
+    return { kind: 'unavailable' };
+  } finally {
+    deps.recordDurableObjectLatency('auth_limiter', deps.now() - startedAt);
+  }
+}
+
+function hasAuthFailureState(state: AuthFailureLimiterResponseBody['state']): boolean {
+  return state.count > 0 || state.windowStartedAtMs > 0 || state.blockedUntilMs > 0;
+}
+
+async function callMcpBoundaryEvaluate<TEnv extends WorkerDurableRuntimeEnv>(
+  env: TEnv,
+  clientId: string,
+  body: Omit<McpBoundaryEvaluateRequestBody, 'action'>,
+  deps: Pick<
+    CreateWorkerDurableRuntimeDeps<TEnv>,
+    'now' | 'recordDurableObjectLatency' | 'recordDurableObjectUnavailable'
+  >,
+): Promise<DurableObjectCheckResult<McpBoundaryEvaluateResponseBody>> {
+  const stub = getAuthLimiterStub(env, `mcp-boundary-bundle:${clientId}`);
+  const startedAt = deps.now();
+  try {
+    const response = await stub.fetch('https://auth-failure-limiter/internal', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        action: 'mcp_boundary_evaluate',
+        ...body,
+      } satisfies McpBoundaryEvaluateRequestBody),
+    });
+    if (!response.ok) {
+      deps.recordDurableObjectUnavailable('auth_limiter');
+      logDurableObjectFailure(
+        'auth_limiter',
+        'mcp_boundary_evaluate',
+        'http_error',
+        response.status,
+      );
+      return { kind: 'unavailable' };
+    }
+    return { kind: 'ok', value: (await response.json()) as McpBoundaryEvaluateResponseBody };
+  } catch {
+    deps.recordDurableObjectUnavailable('auth_limiter');
+    logDurableObjectFailure('auth_limiter', 'mcp_boundary_evaluate', 'fetch_error');
     return { kind: 'unavailable' };
   } finally {
     deps.recordDurableObjectLatency('auth_limiter', deps.now() - startedAt);
@@ -560,26 +617,46 @@ export function createWorkerDurableRuntime<TEnv extends WorkerDurableRuntimeEnv>
     },
 
     async getAuthRateLimitedResponse(clientId, env, nowMs) {
+      const probe = await this.probeAuthRateLimit(clientId, env, nowMs);
+      if (probe.kind === 'allowed') {
+        return null;
+      }
+      return probe.response;
+    },
+
+    async probeAuthRateLimit(clientId, env, nowMs): Promise<AuthRateLimitProbeResult> {
       const cfg = getAuthFailureRateLimitConfig(env);
-      if (!cfg.enabled) return null;
+      if (!cfg.enabled) {
+        return { kind: 'allowed', hasFailureState: false };
+      }
       const limiterState = await callAuthLimiter(env, clientId, 'check', nowMs, deps);
       if (limiterState.kind === 'unavailable') {
-        return deps.jsonError(
-          'Unable to validate authentication rate limit.',
-          503,
-          'auth_rate_limiter_unavailable',
-        );
+        return {
+          kind: 'unavailable',
+          response: deps.jsonError(
+            'Unable to validate authentication rate limit.',
+            503,
+            'auth_rate_limiter_unavailable',
+          ),
+        };
       }
-      if (!limiterState.value.blocked) return null;
-
-      const retryAfterSeconds = limiterState.value.retryAfterSeconds;
-      return deps.jsonError(
-        'Too many failed authentication attempts',
-        429,
-        'auth_rate_limited',
-        { retry_after_seconds: retryAfterSeconds },
-        { 'Retry-After': String(retryAfterSeconds) },
-      );
+      if (limiterState.value.blocked) {
+        const retryAfterSeconds = limiterState.value.retryAfterSeconds;
+        return {
+          kind: 'blocked',
+          response: deps.jsonError(
+            'Too many failed authentication attempts',
+            429,
+            'auth_rate_limited',
+            { retry_after_seconds: retryAfterSeconds },
+            { 'Retry-After': String(retryAfterSeconds) },
+          ),
+        };
+      }
+      return {
+        kind: 'allowed',
+        hasFailureState: hasAuthFailureState(limiterState.value.state),
+      };
     },
 
     async getAuthRouteRateLimitedResponse(bucketId, env, nowMs) {
@@ -626,9 +703,9 @@ export function createWorkerDurableRuntime<TEnv extends WorkerDurableRuntimeEnv>
       await callAuthLimiter(env, clientId, 'record', nowMs, deps);
     },
 
-    async clearAuthFailures(clientId, env, nowMs) {
+    async clearAuthFailures(clientId, env, nowMs, hadFailureState = true) {
       const cfg = getAuthFailureRateLimitConfig(env);
-      if (!cfg.enabled) return;
+      if (!cfg.enabled || !hadFailureState) return;
       await callAuthLimiter(env, clientId, 'clear', nowMs, deps);
     },
 
@@ -646,69 +723,56 @@ export function createWorkerDurableRuntime<TEnv extends WorkerDurableRuntimeEnv>
       }
 
       const adaptiveMaxAttempts = deriveAdaptiveBoundaryRateLimit(request, cfg, contentLength);
-      const boundaryRateLimit = await callAuthLimiter(
-        env,
-        `mcp-boundary:${clientId}`,
-        'record',
-        nowMs,
-        deps,
-        {
-          maxAttempts: adaptiveMaxAttempts,
-          windowMs: cfg.windowMs,
-          blockMs: cfg.blockMs,
-        },
+      const replayFingerprint = await buildMcpReplayFingerprint(
+        request,
+        contentLength,
+        cfg.heavyPayloadBytes,
       );
-      if (boundaryRateLimit.kind === 'unavailable') {
+      const boundaryResult = await callMcpBoundaryEvaluate(
+        env,
+        clientId,
+        {
+          nowMs,
+          boundary: {
+            maxAttempts: adaptiveMaxAttempts,
+            windowMs: cfg.windowMs,
+            blockMs: cfg.blockMs,
+          },
+          ...(replayFingerprint
+            ? {
+                replay: {
+                  fingerprint: hashBoundaryReplayFingerprint(replayFingerprint),
+                  maxAttempts: 2,
+                  windowMs: cfg.replayWindowMs,
+                  blockMs: cfg.replayWindowMs,
+                },
+              }
+            : {}),
+        },
+        deps,
+      );
+      if (boundaryResult.kind === 'unavailable') {
         return deps.jsonError(
           'Unable to enforce MCP boundary protections.',
           503,
           'mcp_boundary_unavailable',
         );
       }
-      if (boundaryRateLimit.value.blocked) {
-        const retryAfterSeconds = boundaryRateLimit.value.retryAfterSeconds;
+      if (boundaryResult.value.blocked) {
+        if (boundaryResult.value.reason === 'replay_detected') {
+          return deps.jsonError(
+            'Replay request detected at MCP boundary.',
+            409,
+            'mcp_replay_detected',
+          );
+        }
+        const retryAfterSeconds = boundaryResult.value.retryAfterSeconds;
         return deps.jsonError(
           'MCP boundary rate limit exceeded.',
           429,
           'mcp_rate_limited',
           { retry_after_seconds: retryAfterSeconds },
           { 'Retry-After': String(retryAfterSeconds) },
-        );
-      }
-
-      const replayFingerprint = await buildMcpReplayFingerprint(
-        request,
-        contentLength,
-        cfg.heavyPayloadBytes,
-      );
-      if (!replayFingerprint) {
-        return null;
-      }
-
-      const replayState = await callAuthLimiter(
-        env,
-        `mcp-replay:${clientId}:${hashBoundaryReplayFingerprint(replayFingerprint)}`,
-        'record',
-        nowMs,
-        deps,
-        {
-          maxAttempts: 2,
-          windowMs: cfg.replayWindowMs,
-          blockMs: cfg.replayWindowMs,
-        },
-      );
-      if (replayState.kind === 'unavailable') {
-        return deps.jsonError(
-          'Unable to enforce MCP replay protections.',
-          503,
-          'mcp_replay_guard_unavailable',
-        );
-      }
-      if (replayState.value.blocked) {
-        return deps.jsonError(
-          'Replay request detected at MCP boundary.',
-          409,
-          'mcp_replay_detected',
         );
       }
 

--- a/src/server/worker-runtime-contract.ts
+++ b/src/server/worker-runtime-contract.ts
@@ -159,6 +159,35 @@ export interface AuthFailureLimiterResponseBody {
   state: AuthFailureState;
 }
 
+export interface McpBoundaryEvaluateRequestBody {
+  action: 'mcp_boundary_evaluate';
+  nowMs: number;
+  boundary: {
+    maxAttempts: number;
+    windowMs: number;
+    blockMs: number;
+  };
+  replay?: {
+    fingerprint: string;
+    maxAttempts: number;
+    windowMs: number;
+    blockMs: number;
+  };
+}
+
+export type McpBoundaryEvaluateBlockReason = 'boundary_rate_limit' | 'replay_detected';
+
+export interface McpBoundaryEvaluateResponseBody {
+  blocked: boolean;
+  retryAfterSeconds: number;
+  reason: McpBoundaryEvaluateBlockReason | null;
+}
+
+export type AuthRateLimitProbeResult =
+  | { kind: 'allowed'; hasFailureState: boolean }
+  | { kind: 'blocked'; response: Response }
+  | { kind: 'unavailable'; response: Response };
+
 export interface SessionRevocationResponseBody {
   revoked: boolean;
 }

--- a/src/worker-mcp.ts
+++ b/src/worker-mcp.ts
@@ -92,6 +92,7 @@ const handleMcpWorkerFetch = createWorkerMcpFetchHandler<WorkerMcpEnv>({
     buildCorsHeaders,
     getClientIdentifier: platform.workerObservabilityRuntime.getClientIdentifier,
     getAuthRateLimitedResponse: platform.workerDurableRuntime.getAuthRateLimitedResponse,
+    probeAuthRateLimit: platform.workerDurableRuntime.probeAuthRateLimit,
     recordAuthFailure: platform.workerDurableRuntime.recordAuthFailure,
     clearAuthFailures: platform.workerDurableRuntime.clearAuthFailures,
     evaluateMcpBoundaryRequest: platform.workerDurableRuntime.evaluateMcpBoundaryRequest,

--- a/src/worker/courtlistener-mcp-agent.ts
+++ b/src/worker/courtlistener-mcp-agent.ts
@@ -48,12 +48,17 @@ export class CourtListenerMCP extends (McpAgent as typeof McpAgent<CourtListener
   /** Set from `worker-mcp.ts` before handling requests. */
   static telemetry: CourtListenerMcpAgentTelemetry | null = null;
 
+  private servicesInitialized = false;
+
   server = new McpServer(
     { name: SERVER_INFO.name, version: SERVER_INFO.version },
     { capabilities: SERVER_CAPABILITIES },
   ) as unknown as InstanceType<typeof McpAgent>['server'];
 
   async init(): Promise<void> {
+    if (this.servicesInitialized) {
+      return;
+    }
     const env = (this as unknown as { env: CourtListenerMcpAgentEnv }).env;
     if (env.COURTLISTENER_API_KEY) {
       process.env.COURTLISTENER_API_KEY = env.COURTLISTENER_API_KEY;
@@ -136,6 +141,7 @@ export class CourtListenerMCP extends (McpAgent as typeof McpAgent<CourtListener
         }
       },
     });
+    this.servicesInitialized = true;
   }
 }
 

--- a/test/unit/test-worker-durable-runtime.ts
+++ b/test/unit/test-worker-durable-runtime.ts
@@ -305,14 +305,8 @@ describe('createWorkerDurableRuntime', () => {
   it('returns a 503 when MCP replay protections are unavailable', async () => {
     const runtime = createRuntime();
     const env: TestEnv = {
-      AUTH_FAILURE_LIMITER: createLimiterNamespace(async (_request, objectName) => {
-        if (objectName?.includes('mcp-boundary:')) {
-          return Response.json({ blocked: false, retryAfterSeconds: 0 });
-        }
-        if (objectName?.includes('mcp-replay:')) {
-          return new Response('unavailable', { status: 503 });
-        }
-        throw new Error(`Unexpected Durable Object name: ${objectName}`);
+      AUTH_FAILURE_LIMITER: createLimiterNamespace(async () => {
+        return new Response('unavailable', { status: 503 });
       }),
       MCP_BOUNDARY_GUARDS_ENABLED: 'true',
     };
@@ -335,9 +329,29 @@ describe('createWorkerDurableRuntime', () => {
     assert.ok(response);
     assert.equal(response?.status, 503);
     assert.deepEqual(await response?.json(), {
-      error: 'Unable to enforce MCP replay protections.',
-      error_code: 'mcp_replay_guard_unavailable',
+      error: 'Unable to enforce MCP boundary protections.',
+      error_code: 'mcp_boundary_unavailable',
     });
+  });
+
+  it('skips auth failure clear when the client has no failure state', async () => {
+    const runtime = createRuntime();
+    const capturedActions: string[] = [];
+    const env: TestEnv = {
+      AUTH_FAILURE_LIMITER: createLimiterNamespace(async (request) => {
+        const body = (await request.json()) as { action?: string };
+        capturedActions.push(body.action ?? 'unknown');
+        return Response.json({
+          blocked: false,
+          retryAfterSeconds: 0,
+          state: { count: 0, windowStartedAtMs: 0, blockedUntilMs: 0 },
+        });
+      }),
+    };
+
+    await runtime.clearAuthFailures('client-1', env, 1_700_000_000_000, false);
+
+    assert.deepEqual(capturedActions, []);
   });
 
   it('treats session lifecycle validation failures as unavailable', async () => {
@@ -633,5 +647,41 @@ describe('AuthFailureLimiterDO cleanup', () => {
     assert.equal(await storage.get('auth_failure_window_ms'), undefined);
     assert.equal(await storage.get('auth_failure_cleanup_at_ms'), undefined);
     assert.equal(storage.alarmAt, null);
+  });
+
+  it('does not sweep expired MCP sessions on touch', async () => {
+    const { object, storage } = createLimiterObject();
+    await storage.put('mcp_session:expired', {
+      sessionId: 'expired',
+      createdAtMs: 0,
+      lastSeenAtMs: 0,
+      idleExpiresAtMs: 1_000,
+      absoluteExpiresAtMs: 1_000,
+    });
+    await storage.put('mcp_session:active', {
+      sessionId: 'active',
+      createdAtMs: 5_000,
+      lastSeenAtMs: 5_000,
+      idleExpiresAtMs: 60_000,
+      absoluteExpiresAtMs: 120_000,
+    });
+
+    await object.fetch(
+      new Request('https://auth-failure-limiter/internal', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'mcp_session_touch',
+          nowMs: 10_000,
+          sessionId: 'active',
+          idleTtlMs: 30_000,
+          absoluteTtlMs: 120_000,
+          evictionSweepLimit: 64,
+        }),
+      }),
+    );
+
+    assert.ok(await storage.get('mcp_session:expired'), 'touch should not sweep stale sessions');
+    assert.ok(await storage.get('mcp_session:active'));
   });
 });


### PR DESCRIPTION
## Summary
- Bundle MCP boundary + replay checks into one auth-limiter DO call per request
- Skip MCP session eviction sweeps on touch (alarms handle cleanup)
- Skip redundant auth-failure clear DO calls when the client has no failure state
- Lazy-init CourtListenerMCP services within each session DO

## Deploy status
Already deployed to production:
- `courtlistener-mcp-auth-limiter` (version `2d72a065`)
- `courtlistener-mcp-mcp` (version `bdfea1b5`)
- `courtlistener-mcp` edge (version `9dcbef0b`)

## Test plan
- [x] Unit tests pass locally (pre-push hook)
- [ ] Monitor `/health` DO latency metrics after merge
- [ ] Confirm MCP clients stay under free-tier DO duration quota

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth rate-limiting and MCP abuse-guard behavior (bundled DO state keys and fewer clears) on a security-sensitive path; mitigated by unit tests and operational docs, but worth monitoring DO latency and quota after deploy.
> 
> **Overview**
> This PR **cuts Durable Object work on the MCP hot path** so production stays under Cloudflare’s free-tier DO duration quota.
> 
> **Auth limiter (`AuthFailureLimiterDO`)** now exposes **`mcp_boundary_evaluate`**, which applies boundary rate limiting and optional replay detection in **one** POST instead of separate stub calls. **`mcp_session_touch`** no longer runs eviction sweeps on every request; alarms still clean up stale sessions.
> 
> **Worker runtime** adds **`probeAuthRateLimit`** so the transport layer learns whether the client already has auth-failure state from the initial `check`. After successful gateway auth, **`clearAuthFailures`** skips the **`clear`** DO round-trip when there was nothing to clear. Boundary enforcement routes through the bundled evaluate call (replay failures surface as **`mcp_boundary_unavailable`** / unified 503 path in tests, not a separate replay-guard error code).
> 
> **`CourtListenerMCP`** session DO **`init()`** runs registry/bootstrap setup only once per instance via a **`servicesInitialized`** guard.
> 
> **Docs** add troubleshooting for DO duration alerts, env toggles to reduce load, and pointers to `/health` metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c0e5bd8b9ba9efda92c1cee03346678fd0de32. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->