### PR TITLE
fix(ci): use Node 20+ for enterprise pipeline builds

### DIFF
--- a/.github/workflows/enterprise-testing.yml
+++ b/.github/workflows/enterprise-testing.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ${{ fromJSON(github.event_name == 'pull_request' && '["20"]' || '["18","20"]') }}
+        node-version: ${{ fromJSON('["20","22"]') }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -389,7 +389,7 @@ jobs:
 
 # Workflow Summary
 # 📋 This comprehensive CI/CD pipeline provides:
-# ✅ Multi-node version testing (Node 18, 20)
+# ✅ Multi-node version testing (Node 20, 22; Vite SPA build requires Node 20+)
 # 🧪 Complete test suite execution (Weeks 1-4)
 # 📊 Coverage reporting and analysis
 # 🔒 Security auditing and quality checks

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "wrangler": "^4.94.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- Enterprise Testing workflow ran `pnpm run build` on Node 18 for `main` pushes, but Vite SPA generation requires Node 20+
- Bump default `NODE_VERSION` and unit-test matrix to Node 20/22
- Align `package.json` engines with `>=20.0.0`

## Test plan
- [x] Pre-push local gate passed
- [ ] Enterprise Testing `pnpm run build` on Node 20 matrix leg


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix and engines metadata only; no application runtime or security logic changes.
> 
> **Overview**
> Raises the **minimum supported Node version to 20** so CI and local installs match what **Vite SPA generation** in `pnpm run build` already requires.
> 
> In **Enterprise Testing**, the workflow default `NODE_VERSION` moves from 18 to **20**, and the unit-test matrix is simplified to always run **20 and 22** (dropping 18 and the PR-vs-push conditional that previously mixed 18 on `main`). Inline comments now call out that the Vite SPA step needs Node 20+.
> 
> **`package.json` `engines.node`** is updated from `>=18.0.0` to **`>=20.0.0`** so package managers and contributors get a consistent floor with the pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0e474273f08b64f9b5474cee0aaa693dab6b54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->