### PR TITLE
fix(ci): skip perf gate checks when API routes are unavailable

### DIFF
--- a/scripts/performance/compare-performance.js
+++ b/scripts/performance/compare-performance.js
@@ -367,6 +367,17 @@ function evaluateThresholds(comparison, thresholds, p95MinDeltaMs) {
   return { warnings, failures };
 }
 
+const DEFAULT_UNRELIABLE_CLASS_ERROR_RATE_PCT = 50;
+
+function isUnreliableEndpointClass(baseline, current, thresholdPct) {
+  return (
+    Number.isFinite(baseline.errorRate) &&
+    Number.isFinite(current.errorRate) &&
+    baseline.errorRate >= thresholdPct &&
+    current.errorRate >= thresholdPct
+  );
+}
+
 function evaluateEndpointClassThresholds(
   baselineClasses,
   currentClasses,
@@ -376,11 +387,22 @@ function evaluateEndpointClassThresholds(
   const warnings = [];
   const failures = [];
   const evaluatedClasses = [];
+  const skippedClasses = [];
+  const unreliableErrorRatePct = Number(
+    process.env.PERF_GATE_UNRELIABLE_CLASS_ERROR_RATE_PCT ??
+      DEFAULT_UNRELIABLE_CLASS_ERROR_RATE_PCT,
+  );
 
   for (const [className, thresholds] of Object.entries(classThresholds)) {
     const baseline = baselineClasses[className];
     const current = currentClasses[className];
     if (!baseline || !current) continue;
+
+    if (isUnreliableEndpointClass(baseline, current, unreliableErrorRatePct)) {
+      skippedClasses.push(className);
+      continue;
+    }
+
     evaluatedClasses.push(className);
 
     if (
@@ -438,7 +460,7 @@ function evaluateEndpointClassThresholds(
     }
   }
 
-  return { warnings, failures, evaluatedClasses };
+  return { warnings, failures, evaluatedClasses, skippedClasses };
 }
 
 function resolvePolicyMode(options) {
@@ -548,6 +570,11 @@ function generateReport(comparison, options = {}) {
   if (endpointThresholdResult.evaluatedClasses.length > 0) {
     console.log(
       `   Endpoint classes evaluated: ${endpointThresholdResult.evaluatedClasses.join(', ')}`,
+    );
+  }
+  if (endpointThresholdResult.skippedClasses?.length > 0) {
+    console.log(
+      `   Endpoint classes skipped (error rate >= ${options.unreliableClassErrorRatePct ?? DEFAULT_UNRELIABLE_CLASS_ERROR_RATE_PCT}%): ${endpointThresholdResult.skippedClasses.join(', ')}`,
     );
   }
 

--- a/scripts/performance/load-profile-suite.js
+++ b/scripts/performance/load-profile-suite.js
@@ -24,6 +24,7 @@ function parseArgs(argv) {
     outputPath: '',
     dryRun: false,
     light: false,
+    classes: [],
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -48,6 +49,18 @@ function parseArgs(argv) {
     else if (arg.startsWith('--auth-token=')) options.authToken = (arg.split('=')[1] || '').trim();
     else if (arg === '--output') options.outputPath = argv[++i] || '';
     else if (arg.startsWith('--output=')) options.outputPath = arg.split('=')[1] || '';
+    else if (arg === '--classes') {
+      options.classes = (argv[++i] || '')
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+    } else if (arg.startsWith('--classes=')) {
+      options.classes = arg
+        .split('=')[1]
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+    }
   }
 
   if (options.light) {
@@ -74,7 +87,35 @@ function printUsage() {
   console.log('  --auth-token <token>   Optional bearer token for MCP/API requests');
   console.log('  --output <file>        Optional output JSON path');
   console.log('  --light                Small local validation run');
+  console.log('  --classes <mcp,api>    Limit scenarios (default: auto-detect worker API routes)');
   console.log('  --dry-run              Print planned scenarios only, no HTTP requests');
+}
+
+function scenarioClass(name) {
+  if (name.startsWith('mcp_')) return 'mcp';
+  if (name.startsWith('api_')) return 'api';
+  if (name.startsWith('auth_')) return 'auth';
+  return '';
+}
+
+async function probeWorkerApiRoutes(baseUrl, timeoutMs) {
+  const session = await fetchWithTiming(`${baseUrl}/api/session`, { method: 'GET' }, timeoutMs);
+  return session.status === 200;
+}
+
+async function resolveEnabledClasses(baseUrl, timeoutMs, explicitClasses) {
+  if (explicitClasses.length > 0) return explicitClasses;
+  const hasWorkerApi = await probeWorkerApiRoutes(baseUrl, timeoutMs);
+  if (hasWorkerApi) return ['mcp', 'api', 'auth'];
+  console.log(
+    'Worker UI API routes unavailable at this base URL; running MCP load scenarios only.',
+  );
+  return ['mcp'];
+}
+
+function filterScenariosByClass(scenarios, enabledClasses) {
+  const allowed = new Set(enabledClasses);
+  return scenarios.filter((scenario) => allowed.has(scenarioClass(scenario.name)));
 }
 
 function percentile(values, p) {
@@ -478,8 +519,22 @@ async function main() {
   }
 
   const healthBefore = await fetchHealthMetrics(options.baseUrl, options.timeoutMs);
-  const csrfToken = await getCsrfToken(options.baseUrl, options.timeoutMs);
-  const scenarios = await createScenarioRunners(options, csrfToken);
+  const enabledClasses = await resolveEnabledClasses(
+    options.baseUrl,
+    options.timeoutMs,
+    options.classes,
+  );
+  const csrfToken = enabledClasses.includes('auth')
+    ? await getCsrfToken(options.baseUrl, options.timeoutMs)
+    : '';
+  const scenarios = filterScenariosByClass(
+    await createScenarioRunners(options, csrfToken),
+    enabledClasses,
+  );
+  if (scenarios.length === 0) {
+    throw new Error(`No load scenarios enabled for classes: ${enabledClasses.join(', ')}`);
+  }
+  console.log(`Enabled scenario classes: ${enabledClasses.join(', ')}`);
 
   const results = [];
   for (const scenario of scenarios) {
@@ -498,6 +553,7 @@ async function main() {
     concurrency: options.concurrency,
     timeout_ms: options.timeoutMs,
     scenario_count: scenarios.length,
+    enabled_classes: enabledClasses,
     summary: buildSummary(results),
     results,
     worker_latency_health: {


### PR DESCRIPTION
## Summary
- `stress-reliability` uses `start:http`, which only exposes MCP routes; API/auth scenarios were 100% errors but still drove false `[api] throughput` regressions between back-to-back runs
- Auto-run MCP-only load scenarios when `/api/session` is unavailable
- Skip endpoint-class throughput/p95 gates when both runs exceed 50% error rate for that class

## Test plan
- [x] Simulated baseline/current reports with 100% api/auth errors — perf gate exits 0
- [x] Pre-push local gate passed


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only performance/load-test and comparison scripts in CI; no production auth or API behavior.
> 
> **Overview**
> Fixes **false perf-gate failures** when CI runs load tests against a base URL that only serves MCP (e.g. `start:http` / stress-reliability) while **api** and **auth** scenarios would always error.
> 
> **`load-profile-suite.js`** now probes `GET /api/session` and, unless `--classes` is set, runs only **mcp** scenarios when worker UI API routes are unavailable; it fetches CSRF only when **auth** is enabled, filters scenarios by class, and records `enabled_classes` in the report.
> 
> **`compare-performance.js`** skips per-class p95/throughput/error thresholds when **both** baseline and current have class error rate ≥ **50%** (override via `PERF_GATE_UNRELIABLE_CLASS_ERROR_RATE_PCT`), and logs which endpoint classes were skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e34e0461356f735b181216d2186a75e8609809. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->