### PR TITLE
fix(security): close CodeQL findings in Cloudflare release checks

### DIFF
--- a/scripts/cloudflare/check-live-inventory.mjs
+++ b/scripts/cloudflare/check-live-inventory.mjs
@@ -172,7 +172,21 @@ export async function collectLiveInventory() {
 
 async function main() {
   const receipt = await collectLiveInventory();
-  console.log(JSON.stringify(receipt, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        schema_version: receipt.schema_version,
+        status: receipt.status,
+        checks: receipt.checks.map(({ id, severity, promotion_blocker }) => ({
+          id,
+          severity,
+          promotion_blocker,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
   if (receipt.status !== 'ok') process.exitCode = 1;
 }
 

--- a/test/unit/test-enhanced-handlers.ts
+++ b/test/unit/test-enhanced-handlers.ts
@@ -1054,7 +1054,10 @@ describe('SmartSearchHandler', () => {
     assert.ok(text.includes('1966-06-13'));
     assert.ok(text.includes('[scotus]'));
     assert.ok(text.includes('1200 cites'));
-    assert.ok(text.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'));
+    const renderedLinks = text.split(/[\s"'`<>()[\]]+/).filter(Boolean);
+    assert.ok(
+      renderedLinks.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'),
+    );
     assert.ok(!text.includes('undefined'));
   });
 


### PR DESCRIPTION
What changed:
- redact live inventory CLI output to emit only safe check summaries
- require an exact rendered CourtListener URL token in the handler test

Why:
- close CodeQL high-severity findings identified during MCP v2 promotion

Impact:
- no runtime API contract change; live inventory diagnostics expose less data

Testing:
- targeted unit coverage passed for live inventory and enhanced handlers
- commit lint/repository hygiene passed
- full GitHub release checks will validate the follow-up

Breaking changes: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small diagnostic-output and test-assertion changes; evaluation logic is unchanged. Less data is logged, which is the intended security tightening.
> 
> **Overview**
> Redacts Cloudflare live-inventory CLI stdout so logs no longer dump account IDs, expected topology, or expected/observed check values. `check-live-inventory` still evaluates the full receipt internally and fails on non-ok status, but prints only `schema_version`, `status`, and per-check `id`/`severity`/`promotion_blocker`.
> 
> Also tightens the Smart Search handler test so the CourtListener URL must appear as an exact token, not as a substring of surrounding text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9380d158505f50f947e66b7bcab450e9a3b1aff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live inventory checks now produce a concise JSON receipt with schema version, status, check IDs, severity, and promotion-blocker status.

* **Bug Fixes**
  * Improved SmartSearch link validation to confirm that complete CourtListener opinion URLs are rendered as links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->