### PR TITLE
fix(security): close CodeQL findings in Cloudflare release checks

### DIFF
--- a/scripts/cloudflare/check-live-inventory.mjs
+++ b/scripts/cloudflare/check-live-inventory.mjs
@@ -172,7 +172,21 @@ export async function collectLiveInventory() {
 
 async function main() {
   const receipt = await collectLiveInventory();
-  console.log(JSON.stringify(receipt, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        schema_version: receipt.schema_version,
+        status: receipt.status,
+        checks: receipt.checks.map(({ id, severity, promotion_blocker }) => ({
+          id,
+          severity,
+          promotion_blocker,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
   if (receipt.status !== 'ok') process.exitCode = 1;
 }
 

--- a/test/unit/test-enhanced-handlers.ts
+++ b/test/unit/test-enhanced-handlers.ts
@@ -1054,7 +1054,10 @@ describe('SmartSearchHandler', () => {
     assert.ok(text.includes('1966-06-13'));
     assert.ok(text.includes('[scotus]'));
     assert.ok(text.includes('1200 cites'));
-    assert.ok(text.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'));
+    const renderedLinks = text.split(/[\s"'`<>()[\]]+/).filter(Boolean);
+    assert.ok(
+      renderedLinks.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'),
+    );
     assert.ok(!text.includes('undefined'));
   });
 

--- a/test/unit/test-enhanced-handlers.ts
+++ b/test/unit/test-enhanced-handlers.ts
@@ -1054,9 +1054,9 @@ describe('SmartSearchHandler', () => {
     assert.ok(text.includes('1966-06-13'));
     assert.ok(text.includes('[scotus]'));
     assert.ok(text.includes('1200 cites'));
-    const renderedLinks = text.split(/[\s"'`<>()[\]]+/).filter(Boolean);
-    assert.ok(
-      renderedLinks.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'),
+    assert.match(
+      text,
+      /(?:^|[\s(])https:\/\/www\.courtlistener\.com\/opinion\/107252\/miranda-v-arizona\/(?:$|[\s)])/,
     );
     assert.ok(!text.includes('undefined'));
   });


### PR DESCRIPTION
What changed:
- redact live inventory CLI output to emit only safe check summaries
- validate the rendered CourtListener URL with exact boundary matching

Why:
- close CodeQL findings identified during MCP v2 promotion

Impact:
- no runtime API contract change; live inventory diagnostics expose less data

Testing:
- targeted unit coverage passed for live inventory and enhanced handlers
- commit lint/repository hygiene passed
- required GitHub checks will validate this policy-compliant promotion branch

Breaking changes: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small diagnostic-output and test-assertion changes; no auth, API, or runtime behavior change. The CLI now exposes less inventory detail, which is the intended security tightening.
> 
> **Overview**
> Reduces what the Cloudflare live-inventory preflight prints, and tightens a CourtListener URL check that CodeQL flagged.
> 
> `check-live-inventory.mjs` now logs only `schema_version`, `status`, and per-check `id`/`severity`/`promotion_blocker`. Account IDs, expected topology, and expected/observed values stay in the in-memory receipt but are no longer dumped to stdout.
> 
> The smart-search unit test now matches the Miranda opinion URL with word-boundary regex instead of a substring `includes`, so a partial URL would fail the assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f9833ef2618d057d87d9fa359fad5e5ff35f49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->