### PR TITLE
fix(test): isolate Cloudflare release probe defaults

### DIFF
--- a/scripts/cloudflare/check-live-inventory.mjs
+++ b/scripts/cloudflare/check-live-inventory.mjs
@@ -172,7 +172,21 @@ export async function collectLiveInventory() {
 
 async function main() {
   const receipt = await collectLiveInventory();
-  console.log(JSON.stringify(receipt, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        schema_version: receipt.schema_version,
+        status: receipt.status,
+        checks: receipt.checks.map(({ id, severity, promotion_blocker }) => ({
+          id,
+          severity,
+          promotion_blocker,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
   if (receipt.status !== 'ok') process.exitCode = 1;
 }
 

--- a/scripts/cloudflare/check-live-inventory.mjs
+++ b/scripts/cloudflare/check-live-inventory.mjs
@@ -172,21 +172,7 @@ export async function collectLiveInventory() {
 
 async function main() {
   const receipt = await collectLiveInventory();
-  console.log(
-    JSON.stringify(
-      {
-        schema_version: receipt.schema_version,
-        status: receipt.status,
-        checks: receipt.checks.map(({ id, severity, promotion_blocker }) => ({
-          id,
-          severity,
-          promotion_blocker,
-        })),
-      },
-      null,
-      2,
-    ),
-  );
+  console.log(JSON.stringify(receipt, null, 2));
   if (receipt.status !== 'ok') process.exitCode = 1;
 }
 

--- a/test/unit/test-cloudflare-release-probes.ts
+++ b/test/unit/test-cloudflare-release-probes.ts
@@ -20,8 +20,19 @@ describe('Cloudflare release probe contracts', () => {
   });
 
   it('defaults probes to the staging environment and enables overrides', () => {
-    const options = parseArgs([]);
-    assert.equal(options.environment, 'staging');
-    assert.equal(options.override, true);
+    const previousEnvironment = process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+    const previousOverride = process.env.RELEASE_VERSION_OVERRIDE;
+    delete process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+    delete process.env.RELEASE_VERSION_OVERRIDE;
+    try {
+      const options = parseArgs([]);
+      assert.equal(options.environment, 'staging');
+      assert.equal(options.override, true);
+    } finally {
+      if (previousEnvironment === undefined) delete process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+      else process.env.CLOUDFLARE_RELEASE_ENVIRONMENT = previousEnvironment;
+      if (previousOverride === undefined) delete process.env.RELEASE_VERSION_OVERRIDE;
+      else process.env.RELEASE_VERSION_OVERRIDE = previousOverride;
+    }
   });
 });

--- a/test/unit/test-enhanced-handlers.ts
+++ b/test/unit/test-enhanced-handlers.ts
@@ -1054,7 +1054,10 @@ describe('SmartSearchHandler', () => {
     assert.ok(text.includes('1966-06-13'));
     assert.ok(text.includes('[scotus]'));
     assert.ok(text.includes('1200 cites'));
-    assert.ok(text.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'));
+    const renderedLinks = text.split(/[\s"'`<>()[\]]+/).filter(Boolean);
+    assert.ok(
+      renderedLinks.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'),
+    );
     assert.ok(!text.includes('undefined'));
   });
 

--- a/test/unit/test-enhanced-handlers.ts
+++ b/test/unit/test-enhanced-handlers.ts
@@ -1054,9 +1054,9 @@ describe('SmartSearchHandler', () => {
     assert.ok(text.includes('1966-06-13'));
     assert.ok(text.includes('[scotus]'));
     assert.ok(text.includes('1200 cites'));
-    const renderedLinks = text.split(/[\s"'`<>()[\]]+/).filter(Boolean);
-    assert.ok(
-      renderedLinks.includes('https://www.courtlistener.com/opinion/107252/miranda-v-arizona/'),
+    assert.match(
+      text,
+      /(?:^|[\s(])https:\/\/www\.courtlistener\.com\/opinion\/107252\/miranda-v-arizona\/(?:$|[\s)])/,
     );
     assert.ok(!text.includes('undefined'));
   });


### PR DESCRIPTION
What changed:
- isolate Cloudflare release environment variables in the release-probe unit test

Why:
- the production release workflow sets CLOUDFLARE_RELEASE_ENVIRONMENT, which previously invalidated the default-staging assertion

Impact:
- test-only change; no runtime behavior change

Testing:
- release-probe test passes with and without the production environment variable

Breaking changes: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stdout contract of a Cloudflare release preflight script, which can affect CI parsers or operators who relied on expected/observed inventory details. Test-only changes are low risk.
> 
> **Overview**
> **Redacts live inventory CLI output.** `check-live-inventory.mjs` no longer dumps the full receipt (account id, expected topology, expected/observed values). It now prints `schema_version`, `status`, and per-check `id` / `severity` / `promotion_blocker` only. Exit code behavior is unchanged.
> 
> **Stabilizes tests.** The release-probe defaults test now clears and restores `CLOUDFLARE_RELEASE_ENVIRONMENT` and `RELEASE_VERSION_OVERRIDE` so production CI env vars cannot fail the staging-default assertion. Smart-search formatting asserts the CourtListener URL as a bounded token rather than a raw substring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29595c6a3cee9c9f233ca83b201d3d23915b93ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live inventory checks now display a concise receipt with status, schema version, check IDs, severity, and promotion-blocker status, without exposing detailed values.

* **Tests**
  * Improved test isolation by preventing environment settings from leaking between tests.
  * Strengthened URL formatting validation to ensure links appear as standalone tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->