### PR TITLE
fix(test): isolate Cloudflare release probe defaults

### DIFF
--- a/test/unit/test-cloudflare-release-probes.ts
+++ b/test/unit/test-cloudflare-release-probes.ts
@@ -20,8 +20,19 @@ describe('Cloudflare release probe contracts', () => {
   });
 
   it('defaults probes to the staging environment and enables overrides', () => {
-    const options = parseArgs([]);
-    assert.equal(options.environment, 'staging');
-    assert.equal(options.override, true);
+    const previousEnvironment = process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+    const previousOverride = process.env.RELEASE_VERSION_OVERRIDE;
+    delete process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+    delete process.env.RELEASE_VERSION_OVERRIDE;
+    try {
+      const options = parseArgs([]);
+      assert.equal(options.environment, 'staging');
+      assert.equal(options.override, true);
+    } finally {
+      if (previousEnvironment === undefined) delete process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+      else process.env.CLOUDFLARE_RELEASE_ENVIRONMENT = previousEnvironment;
+      if (previousOverride === undefined) delete process.env.RELEASE_VERSION_OVERRIDE;
+      else process.env.RELEASE_VERSION_OVERRIDE = previousOverride;
+    }
   });
 });


### PR DESCRIPTION
What changed:
- isolate Cloudflare release environment variables in the release-probe unit test

Why:
- the production release workflow sets CLOUDFLARE_RELEASE_ENVIRONMENT, which previously invalidated the default-staging assertion

Impact:
- test-only change; no runtime behavior change

Testing:
- release-probe test passes with and without the production environment variable

Breaking changes: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only env isolation; no production or security behavior changes.
> 
> **Overview**
> Makes the Cloudflare release-probe unit test independent of CI env vars so default `parseArgs([])` behavior still asserts **staging** and **override enabled**.
> 
> The test now saves, clears, and restores `CLOUDFLARE_RELEASE_ENVIRONMENT` and `RELEASE_VERSION_OVERRIDE`. Production workflows set those variables, which previously broke the default-staging assertion. Test-only; no runtime change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de43fe28b8352bb1b105e33f160dc403fa71df7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing and restoring environment variables during release probe configuration tests.
  * Preserved coverage for staging defaults and explicitly enabled settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->