### PR TITLE
fix(cloudflare): verify account-scoped API tokens

### DIFF
--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
+import { cloudflareRequest } from './lib/cloudflare-api.mjs';
 import {
   WRANGLER_EDGE_CONFIG,
   WRANGLER_MCP_CONFIG,
@@ -202,12 +203,24 @@ async function main() {
     ok(`Wrangler detected: ${version.stdout}`);
   }
 
-  const whoami = runWrangler(projectRoot, ['whoami']);
-  if (whoami.status !== 0) {
-    fail('Not authenticated with Cloudflare. Run `pnpm exec wrangler login`.');
-    hasCriticalError = true;
+  const configuredAccountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
+  const configuredApiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+  if (configuredAccountId && configuredApiToken) {
+    try {
+      await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
+      ok(`Cloudflare account authentication is valid for ${configuredAccountId}.`);
+    } catch {
+      fail('Cloudflare account authentication failed for the configured account.');
+      hasCriticalError = true;
+    }
   } else {
-    ok('Cloudflare authentication is valid.');
+    const whoami = runWrangler(projectRoot, ['whoami']);
+    if (whoami.status !== 0) {
+      fail('Not authenticated with Cloudflare. Run `pnpm exec wrangler login`.');
+      hasCriticalError = true;
+    } else {
+      ok('Cloudflare authentication is valid.');
+    }
   }
 
   let edgeConfig;

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,7 +3,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
-import { cloudflareRequest } from './lib/cloudflare-api.mjs';
 import {
   WRANGLER_EDGE_CONFIG,
   WRANGLER_MCP_CONFIG,
@@ -68,6 +67,23 @@ function parseBoolean(rawValue) {
   if (!rawValue) return false;
   const normalized = rawValue.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+async function verifyAccountScopedToken(accountId, apiToken) {
+  try {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/tokens/verify`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          Accept: 'application/json',
+        },
+      },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 function hasConfiguredValue(record, key) {
@@ -206,10 +222,9 @@ async function main() {
   const configuredAccountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
   const configuredApiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
   if (configuredAccountId && configuredApiToken) {
-    try {
-      await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
+    if (await verifyAccountScopedToken(configuredAccountId, configuredApiToken)) {
       ok('Cloudflare account authentication is valid.');
-    } catch {
+    } else {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;
     }

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -208,7 +208,7 @@ async function main() {
   if (configuredAccountId && configuredApiToken) {
     try {
       await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
-      ok(`Cloudflare account authentication is valid for ${configuredAccountId}.`);
+      ok('Cloudflare account authentication is valid.');
     } catch {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;

--- a/test/unit/test-cloudflare-release-probes.ts
+++ b/test/unit/test-cloudflare-release-probes.ts
@@ -20,8 +20,19 @@ describe('Cloudflare release probe contracts', () => {
   });
 
   it('defaults probes to the staging environment and enables overrides', () => {
-    const options = parseArgs([]);
-    assert.equal(options.environment, 'staging');
-    assert.equal(options.override, true);
+    const previousEnvironment = process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+    const previousOverride = process.env.RELEASE_VERSION_OVERRIDE;
+    delete process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+    delete process.env.RELEASE_VERSION_OVERRIDE;
+    try {
+      const options = parseArgs([]);
+      assert.equal(options.environment, 'staging');
+      assert.equal(options.override, true);
+    } finally {
+      if (previousEnvironment === undefined) delete process.env.CLOUDFLARE_RELEASE_ENVIRONMENT;
+      else process.env.CLOUDFLARE_RELEASE_ENVIRONMENT = previousEnvironment;
+      if (previousOverride === undefined) delete process.env.RELEASE_VERSION_OVERRIDE;
+      else process.env.RELEASE_VERSION_OVERRIDE = previousOverride;
+    }
   });
 });


### PR DESCRIPTION
## What changed
- Verify configured Cloudflare API tokens through the account-scoped token endpoint.
- Preserve Wrangler `whoami` fallback for local OAuth authentication.

## Why
Cloudflare account-scoped API tokens are valid for Workers account operations but Wrangler `whoami` checks the user-scoped endpoint and rejects them, blocking the release controller before upload.

## Impact
- No production resources changed.
- The release controller can authenticate with the configured account token.
- Existing local OAuth behavior remains unchanged.

## Testing
- `pnpm run cloudflare:check` with the configured account token: passed.
- Cloudflare account token verification: passed.
- Pre-push local gate reached generated-file drift from existing build outputs; unrelated generated files remain unstaged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/release preflight and test isolation only; no production runtime or deploy config changes.
> 
> **Overview**
> **Cloudflare setup check** now accepts CI-style credentials: when both `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` are set, it validates auth via the account-scoped **`/accounts/{id}/tokens/verify`** API (`cloudflareRequest`) instead of Wrangler `whoami`, which rejects account tokens that still work for Workers releases.
> 
> If those env vars are missing, behavior is unchanged—**`pnpm exec wrangler login`** / `whoami` remains the auth path.
> 
> **Unit test** for release probe `parseArgs` defaults clears and restores `CLOUDFLARE_RELEASE_ENVIRONMENT` and `RELEASE_VERSION_OVERRIDE` so defaults (`staging`, override on) are asserted without leaking from the runner environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4790393b70cd4bd6b66c4ecb6c8a5f2817fb1bff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare setup validation when account credentials are configured.
  * Setup failures from Cloudflare account authentication are now reported as critical.
  * Preserved the existing authentication fallback when account credentials are unavailable.
  * Improved release probe test reliability by preventing environment settings from affecting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->