### PR TITLE
fix(cloudflare): identify hosted OAuth probes

### DIFF
--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
+import { cloudflareRequest } from './lib/cloudflare-api.mjs';
 import {
   WRANGLER_EDGE_CONFIG,
   WRANGLER_MCP_CONFIG,
@@ -67,23 +68,6 @@ function parseBoolean(rawValue) {
   if (!rawValue) return false;
   const normalized = rawValue.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
-}
-
-async function verifyAccountScopedToken(accountId, apiToken) {
-  try {
-    const response = await fetch(
-      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/tokens/verify`,
-      {
-        headers: {
-          Authorization: `Bearer ${apiToken}`,
-          Accept: 'application/json',
-        },
-      },
-    );
-    return response.ok;
-  } catch {
-    return false;
-  }
 }
 
 function hasConfiguredValue(record, key) {
@@ -222,9 +206,10 @@ async function main() {
   const configuredAccountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
   const configuredApiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
   if (configuredAccountId && configuredApiToken) {
-    if (await verifyAccountScopedToken(configuredAccountId, configuredApiToken)) {
-      ok('Cloudflare account authentication is valid.');
-    } else {
+    try {
+      await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
+      ok(`Cloudflare account authentication is valid for ${configuredAccountId}.`);
+    } catch {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;
     }

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -18,6 +18,7 @@ const wranglerEdgeConfig = WRANGLER_EDGE_CONFIG;
 const wranglerMcpConfig = WRANGLER_MCP_CONFIG;
 
 const requiredMcpSecrets = ['COURTLISTENER_API_KEY'];
+const HOSTED_PROBE_USER_AGENT = 'courtlistener-mcp-oauth-probe/1.0';
 
 function color(text, code) {
   return `\x1b[${code}m${text}\x1b[0m`;
@@ -700,6 +701,7 @@ async function main() {
 
       const hostedAuth = await checkEndpoint(baseUrl, '/auth/start?continue=1', {
         redirect: 'manual',
+        headers: { 'User-Agent': HOSTED_PROBE_USER_AGENT },
       });
       const hostedAuthReadyHeader = hostedAuth.headers.get('x-hosted-auth-ready');
       const hostedAuthStatus = hostedAuth.headers.get('x-hosted-auth-status');

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,7 +3,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
-import { cloudflareRequest } from './lib/cloudflare-api.mjs';
 import {
   WRANGLER_EDGE_CONFIG,
   WRANGLER_MCP_CONFIG,
@@ -68,6 +67,23 @@ function parseBoolean(rawValue) {
   if (!rawValue) return false;
   const normalized = rawValue.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+async function verifyAccountScopedToken(accountId, apiToken) {
+  try {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/tokens/verify`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          Accept: 'application/json',
+        },
+      },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 function hasConfiguredValue(record, key) {
@@ -206,10 +222,9 @@ async function main() {
   const configuredAccountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
   const configuredApiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
   if (configuredAccountId && configuredApiToken) {
-    try {
-      await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
+    if (await verifyAccountScopedToken(configuredAccountId, configuredApiToken)) {
       ok('Cloudflare account authentication is valid.');
-    } catch {
+    } else {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;
     }

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -208,7 +208,7 @@ async function main() {
   if (configuredAccountId && configuredApiToken) {
     try {
       await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
-      ok(`Cloudflare account authentication is valid for ${configuredAccountId}.`);
+      ok('Cloudflare account authentication is valid.');
     } catch {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;


### PR DESCRIPTION
## What changed
- Send the documented OAuth probe User-Agent on the hosted `/auth/start` readiness check.

## Why
- Cloudflare edge challenge behavior varies by request identity; the release gate was not identifying itself as the approved monitoring probe.

## Impact
- No Worker code or production traffic policy changed.
- This enables the existing narrow probe policy where supported and preserves fail-closed readiness checks.

## Testing
- Local pre-push gate passed.
- 89 unit test files and 163 SPA tests passed.
- Live `/auth/start` returned redirect-ready when sent with the probe User-Agent.

## Deployment
- Production promotion remains behind the Cloudflare release controller canary and receipt gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to deploy/setup scripts and a unit test; no Worker runtime or production auth policy is modified.
> 
> **Overview**
> **Hosted OAuth readiness probes** now send the documented `courtlistener-mcp-oauth-probe/1.0` **User-Agent** on the `/auth/start?continue=1` check in `check-setup.js`, so release/setup gates match the WAF probe allowlist and behave consistently under Cloudflare edge challenges.
> 
> **Cloudflare authentication in the setup check** no longer relies only on `wrangler whoami`. When **`CLOUDFLARE_ACCOUNT_ID`** and **`CLOUDFLARE_API_TOKEN`** are both set, it validates them via the account **tokens/verify** API; otherwise it keeps the existing Wrangler login path.
> 
> The **release probe unit test** for default `parseArgs` behavior now **clears and restores** `CLOUDFLARE_RELEASE_ENVIRONMENT` and `RELEASE_VERSION_OVERRIDE` so defaults are asserted without leaking CI env state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b9775ca40dfebdca733f24f453611c8a0733a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare setup checks now support API-token authentication through environment variables, including account- and user-scoped tokens.
  * Verification results clearly indicate whether authentication succeeds or fails, with a fallback to the existing sign-in check when no token is provided.
  * Hosted authentication readiness checks now identify their requests with a dedicated header.

* **Bug Fixes**
  * Release probe defaults now remain reliable regardless of pre-existing environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->