### PR TITLE
feat(ci): route validation through the NUC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
   full-validation:
     name: Full Validation
-    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     needs: test
     steps:
       - name: Checkout repository
@@ -297,7 +297,7 @@ jobs:
 
   browser-auth:
     name: Browser Auth CI
-    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     needs: detect-relevant-changes
     if: >-
       ${{
@@ -331,7 +331,7 @@ jobs:
 
   hardening-release-gates:
     name: Hardening Release Gates (${{ matrix.gate }})
-    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     needs: detect-relevant-changes
     if: >-
       ${{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
   test:
     name: Smoke Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -173,7 +173,7 @@ jobs:
 
   full-validation:
     name: Full Validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     needs: test
     steps:
       - name: Checkout repository
@@ -297,7 +297,7 @@ jobs:
 
   browser-auth:
     name: Browser Auth CI
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     needs: detect-relevant-changes
     if: >-
       ${{
@@ -331,7 +331,7 @@ jobs:
 
   hardening-release-gates:
     name: Hardening Release Gates (${{ matrix.gate }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     needs: detect-relevant-changes
     if: >-
       ${{
@@ -504,7 +504,7 @@ jobs:
 
   mcp-compliance:
     name: MCP Protocol Compliance
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     needs: [detect-relevant-changes, test]
     if: >-
       ${{
@@ -564,7 +564,7 @@ jobs:
 
   remote-server-test:
     name: Remote Server Validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     if: >-
       ${{
         github.event_name == 'push' &&
@@ -609,7 +609,7 @@ jobs:
 
   security-check:
     name: Security & Code Quality
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,7 +609,7 @@ jobs:
 
   security-check:
     name: Security & Code Quality
-    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/cloudflare-release.yml
+++ b/.github/workflows/cloudflare-release.yml
@@ -22,6 +22,11 @@ on:
         required: true
         default: false
         type: boolean
+      resume_from_run_id:
+        description: Prior successful release run whose validated state should be resumed
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: cloudflare-release-${{ inputs.environment }}
@@ -65,6 +70,20 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Restore validated release state
+        if: ${{ inputs.resume_from_run_id != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESUME_FROM_RUN_ID: ${{ inputs.resume_from_run_id }}
+        run: |
+          resume_dir="$(mktemp -d /tmp/courtlistener-mcp-release-state-XXXXXX)"
+          gh run download "$RESUME_FROM_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "cloudflare-release-${CLOUDFLARE_RELEASE_ID}" \
+            --dir "$resume_dir"
+          cp "$resume_dir/release-state.json" release-state.json
+          test -s release-state.json
 
       - name: Run repository release gates
         run: |

--- a/.github/workflows/cloudflare-release.yml
+++ b/.github/workflows/cloudflare-release.yml
@@ -53,6 +53,7 @@ jobs:
       CLOUDFLARE_CANARY_PERCENT: ${{ inputs.canary_percent }}
       CLOUDFLARE_PROBE_DIRECTORY: release-probes
       GITHUB_SHA: ${{ github.sha }}
+      CLOUDFLARE_RELEASE_SOURCE_SHA: ${{ github.sha }}
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_ACTOR: ${{ github.actor }}
     steps:
@@ -84,6 +85,7 @@ jobs:
             --dir "$resume_dir"
           cp "$resume_dir/release-state.json" release-state.json
           test -s release-state.json
+          echo "CLOUDFLARE_RELEASE_SOURCE_SHA=$(jq -r '.source_sha' release-state.json)" >> "$GITHUB_ENV"
 
       - name: Run repository release gates
         run: |
@@ -104,7 +106,7 @@ jobs:
               --environment "$CLOUDFLARE_RELEASE_ENVIRONMENT" \
               --phase upload \
               --release-id "$CLOUDFLARE_RELEASE_ID" \
-              --source-sha "$GITHUB_SHA" \
+              --source-sha "$CLOUDFLARE_RELEASE_SOURCE_SHA" \
               --state-file release-state.json
 
       - name: Canary versioned Edge and MCP Workers
@@ -113,7 +115,7 @@ jobs:
             --environment "$CLOUDFLARE_RELEASE_ENVIRONMENT" \
             --phase canary \
             --release-id "$CLOUDFLARE_RELEASE_ID" \
-            --source-sha "$GITHUB_SHA" \
+            --source-sha "$CLOUDFLARE_RELEASE_SOURCE_SHA" \
             --state-file release-state.json
 
       - name: Run version-override protocol probes
@@ -135,7 +137,7 @@ jobs:
             --environment "$CLOUDFLARE_RELEASE_ENVIRONMENT" \
             --phase promote \
             --release-id "$CLOUDFLARE_RELEASE_ID" \
-            --source-sha "$GITHUB_SHA" \
+            --source-sha "$CLOUDFLARE_RELEASE_SOURCE_SHA" \
             --state-file release-state.json
 
       - name: Verify promoted public behavior
@@ -155,7 +157,7 @@ jobs:
             --environment "$CLOUDFLARE_RELEASE_ENVIRONMENT" \
             --phase rollback \
             --release-id "$CLOUDFLARE_RELEASE_ID" \
-            --source-sha "$GITHUB_SHA" \
+            --source-sha "$CLOUDFLARE_RELEASE_SOURCE_SHA" \
             --state-file release-state.json
 
       - name: Finalize and validate redacted release receipt
@@ -177,7 +179,7 @@ jobs:
             --environment "$CLOUDFLARE_RELEASE_ENVIRONMENT" \
             --phase finalize \
             --release-id "$CLOUDFLARE_RELEASE_ID" \
-            --source-sha "$GITHUB_SHA" \
+            --source-sha "$CLOUDFLARE_RELEASE_SOURCE_SHA" \
             --state-file release-state.json \
             --receipt-file release-receipt.json \
             --probe-directory "$probe_directory" \

--- a/.github/workflows/e2e-auth-chat-flow.yml
+++ b/.github/workflows/e2e-auth-chat-flow.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   hosted-oauth-handshake:
     name: End-to-End Hosted OAuth Handshake
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
 
     env:
       OAUTH_BASE_URL: ${{ secrets.E2E_BASE_URL }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   performance-monitoring:
     name: Performance Monitoring
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
 
     steps:
       - name: Checkout repository
@@ -196,7 +196,7 @@ jobs:
 
   health-check:
     name: Remote Server Health Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
     if: github.event_name == 'workflow_dispatch'
 
     steps:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -53,13 +53,15 @@ jobs:
           echo "⚡ Running performance monitoring for $TEST_ENVIRONMENT environment(s)..."
 
           mkdir -p performance-data
+          LOCAL_WORKERS_PORT="$(node scripts/dev/find-free-port.mjs)"
+          echo "Allocated local Worker port: $LOCAL_WORKERS_PORT"
           REMOTE_BASE_URL="$(node scripts/resolve-remote-endpoints.js "$REMOTE_SERVER_URL" --field baseUrl)"
 
           start_local_workers() {
-            LOCAL_WORKERS_CONFIG=test pnpm run dev:workers > performance-data/local-workers.log 2>&1 &
+            LOCAL_WORKERS_PORT="$LOCAL_WORKERS_PORT" LOCAL_WORKERS_CONFIG=test pnpm run dev:workers > performance-data/local-workers.log 2>&1 &
             LOCAL_WORKERS_PID=$!
             for attempt in $(seq 1 30); do
-              if LOCAL_HEALTH_URL=http://127.0.0.1:8787 LOCAL_HEALTH_TIMEOUT_MS=1000 node scripts/dev/check-local-health.mjs >/dev/null 2>&1; then
+              if LOCAL_HEALTH_URL="http://127.0.0.1:$LOCAL_WORKERS_PORT" LOCAL_HEALTH_TIMEOUT_MS=1000 node scripts/dev/check-local-health.mjs >/dev/null 2>&1; then
                 return 0
               fi
               sleep 1
@@ -87,7 +89,7 @@ jobs:
               echo "Testing local server performance..."
               start_local_workers
               trap stop_local_workers EXIT
-              run_profile http://127.0.0.1:8787 performance-data/local.json performance-data/local.txt
+              run_profile "http://127.0.0.1:$LOCAL_WORKERS_PORT" performance-data/local.json performance-data/local.txt
               ;;
             "remote")
               echo "Testing remote server performance..."
@@ -97,7 +99,7 @@ jobs:
               echo "Testing both local and remote server performance..."
               start_local_workers
               trap stop_local_workers EXIT
-              run_profile http://127.0.0.1:8787 performance-data/local.json performance-data/local.txt
+              run_profile "http://127.0.0.1:$LOCAL_WORKERS_PORT" performance-data/local.json performance-data/local.txt
               run_profile "$REMOTE_BASE_URL" performance-data/remote.json performance-data/remote.txt
               ;;
           esac

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -197,7 +197,11 @@ jobs:
   health-check:
     name: Remote Server Health Check
     runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.environment != 'local'
+      }}
 
     steps:
       - name: Check remote server health

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -1,0 +1,32 @@
+name: Self-Hosted Runner Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runner-smoke:
+    name: Verify NUC Runner
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    steps:
+      - name: Verify runner identity
+        env:
+          RUNNER_NAME: ${{ runner.name }}
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+        run: |
+          echo "Runner: $RUNNER_NAME"
+          echo "OS: $RUNNER_OS"
+          echo "Architecture: $RUNNER_ARCH"
+          test "$RUNNER_NAME" = "automation-nuc-courtlistener-mcp"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+
+      - name: Verify host runtime
+        run: |
+          hostname
+          uname -srm
+          command -v git

--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ For a deployed self-hosted topology, authenticate Wrangler and use the
 Cloudflare release workflow after configuring the required Worker secrets; the
 production source of truth is the `wrangler.*.jsonc` configuration.
 
+### Optional NUC validation runner
+
+Validation, performance, and hosted OAuth test jobs can use a dedicated trusted
+Linux NUC by setting the repository variable `CI_LINUX_RUNNER` to this JSON
+array:
+
+```text
+["self-hosted","linux","x64","nuc","courtlistener-mcp"]
+```
+
+Until that variable is set and a runner with all five labels is registered,
+these jobs automatically use `ubuntu-latest`. Keep the NUC dedicated to this
+repository and do not use it for untrusted public pull-request workloads unless
+the repository and runner trust boundary has been reviewed. The Cloudflare
+release controller, production credentials, npm publishing, and deployment
+authority remain on GitHub-hosted runners.
+
 ## Publishing to npm
 
 This repository is configured to publish from `.github/workflows/release.yml`

--- a/README.md
+++ b/README.md
@@ -99,19 +99,21 @@ production source of truth is the `wrangler.*.jsonc` configuration.
 
 ### Optional NUC validation runner
 
-Validation, performance, and hosted OAuth test jobs can use a dedicated trusted
-Linux NUC by setting the repository variable `CI_LINUX_RUNNER` to this JSON
-array:
+Non-browser validation, MCP, remote, and performance jobs can use a dedicated
+trusted Linux NUC by setting the repository variable `CI_LINUX_RUNNER` to this
+JSON array:
 
 ```text
 ["self-hosted","linux","x64","nuc","courtlistener-mcp"]
 ```
 
 Until that variable is set and a runner with all five labels is registered,
-these jobs automatically use `ubuntu-latest`. Keep the NUC dedicated to this
-repository and do not use it for untrusted public pull-request workloads unless
-the repository and runner trust boundary has been reviewed. Security scanning,
-the Cloudflare release controller, production credentials, npm publishing, and
+these jobs automatically use `ubuntu-latest`. Browser-dependent validation and
+security scanning remain on GitHub-hosted runners because they require hosted
+system packages and security-tool artifact assumptions. Keep the NUC dedicated
+to this repository and do not use it for untrusted public pull-request workloads
+unless the repository and runner trust boundary has been reviewed. The
+Cloudflare release controller, production credentials, npm publishing, and
 deployment authority remain on GitHub-hosted runners.
 
 ## Publishing to npm

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ array:
 Until that variable is set and a runner with all five labels is registered,
 these jobs automatically use `ubuntu-latest`. Keep the NUC dedicated to this
 repository and do not use it for untrusted public pull-request workloads unless
-the repository and runner trust boundary has been reviewed. The Cloudflare
-release controller, production credentials, npm publishing, and deployment
-authority remain on GitHub-hosted runners.
+the repository and runner trust boundary has been reviewed. Security scanning,
+the Cloudflare release controller, production credentials, npm publishing, and
+deployment authority remain on GitHub-hosted runners.
 
 ## Publishing to npm
 

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
+import { cloudflareRequest } from './lib/cloudflare-api.mjs';
 import {
   WRANGLER_EDGE_CONFIG,
   WRANGLER_MCP_CONFIG,
@@ -67,23 +68,6 @@ function parseBoolean(rawValue) {
   if (!rawValue) return false;
   const normalized = rawValue.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
-}
-
-async function verifyAccountScopedToken(accountId, apiToken) {
-  try {
-    const response = await fetch(
-      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/tokens/verify`,
-      {
-        headers: {
-          Authorization: `Bearer ${apiToken}`,
-          Accept: 'application/json',
-        },
-      },
-    );
-    return response.ok;
-  } catch {
-    return false;
-  }
 }
 
 function hasConfiguredValue(record, key) {
@@ -222,9 +206,10 @@ async function main() {
   const configuredAccountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
   const configuredApiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
   if (configuredAccountId && configuredApiToken) {
-    if (await verifyAccountScopedToken(configuredAccountId, configuredApiToken)) {
-      ok('Cloudflare account authentication is valid.');
-    } else {
+    try {
+      await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
+      ok(`Cloudflare account authentication is valid for ${configuredAccountId}.`);
+    } catch {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;
     }

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -18,6 +18,7 @@ const wranglerEdgeConfig = WRANGLER_EDGE_CONFIG;
 const wranglerMcpConfig = WRANGLER_MCP_CONFIG;
 
 const requiredMcpSecrets = ['COURTLISTENER_API_KEY'];
+const HOSTED_PROBE_USER_AGENT = 'courtlistener-mcp-oauth-probe/1.0';
 
 function color(text, code) {
   return `\x1b[${code}m${text}\x1b[0m`;
@@ -700,6 +701,7 @@ async function main() {
 
       const hostedAuth = await checkEndpoint(baseUrl, '/auth/start?continue=1', {
         redirect: 'manual',
+        headers: { 'User-Agent': HOSTED_PROBE_USER_AGENT },
       });
       const hostedAuthReadyHeader = hostedAuth.headers.get('x-hosted-auth-ready');
       const hostedAuthStatus = hostedAuth.headers.get('x-hosted-auth-status');

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -3,7 +3,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isCloudflareAccessLoginRedirect } from './url-helpers.js';
-import { cloudflareRequest } from './lib/cloudflare-api.mjs';
 import {
   WRANGLER_EDGE_CONFIG,
   WRANGLER_MCP_CONFIG,
@@ -68,6 +67,23 @@ function parseBoolean(rawValue) {
   if (!rawValue) return false;
   const normalized = rawValue.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+async function verifyAccountScopedToken(accountId, apiToken) {
+  try {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/tokens/verify`,
+      {
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          Accept: 'application/json',
+        },
+      },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 function hasConfiguredValue(record, key) {
@@ -206,10 +222,9 @@ async function main() {
   const configuredAccountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
   const configuredApiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
   if (configuredAccountId && configuredApiToken) {
-    try {
-      await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
+    if (await verifyAccountScopedToken(configuredAccountId, configuredApiToken)) {
       ok('Cloudflare account authentication is valid.');
-    } catch {
+    } else {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;
     }

--- a/scripts/cloudflare/check-setup.js
+++ b/scripts/cloudflare/check-setup.js
@@ -208,7 +208,7 @@ async function main() {
   if (configuredAccountId && configuredApiToken) {
     try {
       await cloudflareRequest(`/accounts/${configuredAccountId}/tokens/verify`);
-      ok(`Cloudflare account authentication is valid for ${configuredAccountId}.`);
+      ok('Cloudflare account authentication is valid.');
     } catch {
       fail('Cloudflare account authentication failed for the configured account.');
       hasCriticalError = true;

--- a/scripts/cloudflare/release-controller.mjs
+++ b/scripts/cloudflare/release-controller.mjs
@@ -125,7 +125,7 @@ function runWrangler(args, { allowFailure = false } = {}) {
 }
 
 export function parseVersionId(output) {
-  const match = output.match(/Worker Version ID:\s*([0-9a-f-]{36})/iu);
+  const match = output.match(/(?:Worker|Current) Version ID:\s*([0-9a-f-]{36})/iu);
   if (!match) throw new Error('Wrangler upload output did not contain a Worker Version ID.');
   return match[1];
 }

--- a/scripts/dev/find-free-port.mjs
+++ b/scripts/dev/find-free-port.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import net from 'node:net';
+
+const server = net.createServer();
+
+server.once('error', (error) => {
+  console.error(`Unable to allocate a local port: ${error.message}`);
+  process.exit(1);
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    console.error('Unable to determine the allocated local port');
+    process.exit(1);
+  }
+  console.log(address.port);
+  server.close();
+});

--- a/scripts/dev/run-local-workers.mjs
+++ b/scripts/dev/run-local-workers.mjs
@@ -23,17 +23,21 @@ if (!existsSync(wranglerBinary)) {
 }
 
 console.log('Starting local Edge + MCP Workers with a connected MCP_SERVICE binding.');
-console.log('Edge is exposed on :8787; the MCP Worker is internal to the local binding.');
-console.log('Vite SPA dev should proxy to http://localhost:8787 (see vite.config.ts)\n');
 
 const useTestConfigs = process.env.LOCAL_WORKERS_CONFIG === 'test';
 const edgeConfig = useTestConfigs ? 'wrangler.edge.test.jsonc' : 'wrangler.edge.jsonc';
 const mcpConfig = useTestConfigs ? 'wrangler.mcp.test.jsonc' : 'wrangler.mcp.jsonc';
+const port = process.env.LOCAL_WORKERS_PORT ?? '8787';
+if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65535) {
+  console.error(`Invalid LOCAL_WORKERS_PORT: ${port}`);
+  process.exit(1);
+}
 if (useTestConfigs) {
   console.log('Using offline test Worker configs (no remote Cloudflare bindings).\n');
 }
 
-const worker = spawn(wranglerBinary, ['dev', '-c', edgeConfig, '-c', mcpConfig, '--port', '8787'], {
+console.log(`Starting local Workers on 127.0.0.1:${port}.`);
+const worker = spawn(wranglerBinary, ['dev', '-c', edgeConfig, '-c', mcpConfig, '--port', port], {
   cwd: repoRoot,
   stdio: 'inherit',
   env: process.env,

--- a/test/unit/test-cloudflare-release-controller.ts
+++ b/test/unit/test-cloudflare-release-controller.ts
@@ -27,6 +27,13 @@ describe('Cloudflare release controller contracts', () => {
     );
   });
 
+  it('extracts version IDs from Wrangler direct-deploy output', () => {
+    assert.equal(
+      parseVersionId('Deployed worker\nCurrent Version ID: 123e4567-e89b-12d3-a456-426614174000'),
+      '123e4567-e89b-12d3-a456-426614174000',
+    );
+  });
+
   it('reads the latest active deployment while ignoring wrapper output', () => {
     const output = `[WARN] pnpm warning\n[
       {

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -62,6 +62,7 @@ describe('GitHub workflow hardening', () => {
     assert.match(workflow, /resume_from_run_id:/);
     assert.match(workflow, /Restore validated release state/);
     assert.match(workflow, /gh run download/);
+    assert.match(workflow, /CLOUDFLARE_RELEASE_SOURCE_SHA/);
     assert.match(
       workflow,
       /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7/,

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -78,7 +78,7 @@ describe('GitHub workflow hardening', () => {
     const runnerExpression =
       /runs-on: \$\{\{ fromJSON\(vars\.CI_LINUX_RUNNER \|\| '"ubuntu-latest"'\) \}\}/g;
 
-    assert.equal([...ciWorkflow.matchAll(runnerExpression)].length, 7);
+    assert.equal([...ciWorkflow.matchAll(runnerExpression)].length, 6);
     assert.equal([...performanceWorkflow.matchAll(runnerExpression)].length, 2);
     assert.equal([...e2eWorkflow.matchAll(runnerExpression)].length, 1);
     assert.equal([...runnerSmokeWorkflow.matchAll(runnerExpression)].length, 1);

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -78,13 +78,25 @@ describe('GitHub workflow hardening', () => {
     const runnerExpression =
       /runs-on: \$\{\{ fromJSON\(vars\.CI_LINUX_RUNNER \|\| '"ubuntu-latest"'\) \}\}/g;
 
-    assert.equal([...ciWorkflow.matchAll(runnerExpression)].length, 6);
+    assert.equal([...ciWorkflow.matchAll(runnerExpression)].length, 3);
     assert.equal([...performanceWorkflow.matchAll(runnerExpression)].length, 2);
     assert.equal([...e2eWorkflow.matchAll(runnerExpression)].length, 1);
     assert.equal([...runnerSmokeWorkflow.matchAll(runnerExpression)].length, 1);
     assert.match(runnerSmokeWorkflow, /test "\$RUNNER_NAME" = "automation-nuc-courtlistener-mcp"/);
     assert.match(cloudflareReleaseWorkflow, /runs-on: ubuntu-latest/);
     assert.doesNotMatch(cloudflareReleaseWorkflow, /CI_LINUX_RUNNER/);
+    assert.match(
+      ciWorkflow,
+      /full-validation:\n    name: Full Validation\n    runs-on: ubuntu-latest/,
+    );
+    assert.match(
+      ciWorkflow,
+      /browser-auth:\n    name: Browser Auth CI\n    runs-on: ubuntu-latest/,
+    );
+    assert.match(
+      ciWorkflow,
+      /hardening-release-gates:\n    name: Hardening Release Gates \(\$\{\{ matrix\.gate \}\}\)\n    runs-on: ubuntu-latest/,
+    );
   });
 
   it('does not eval secret-derived remote endpoint output in CI', () => {

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -73,6 +73,7 @@ describe('GitHub workflow hardening', () => {
     const ciWorkflow = read('../../.github/workflows/ci.yml');
     const performanceWorkflow = read('../../.github/workflows/performance.yml');
     const e2eWorkflow = read('../../.github/workflows/e2e-auth-chat-flow.yml');
+    const runnerSmokeWorkflow = read('../../.github/workflows/runner-smoke.yml');
     const cloudflareReleaseWorkflow = read('../../.github/workflows/cloudflare-release.yml');
     const runnerExpression =
       /runs-on: \$\{\{ fromJSON\(vars\.CI_LINUX_RUNNER \|\| '"ubuntu-latest"'\) \}\}/g;
@@ -80,6 +81,8 @@ describe('GitHub workflow hardening', () => {
     assert.equal([...ciWorkflow.matchAll(runnerExpression)].length, 7);
     assert.equal([...performanceWorkflow.matchAll(runnerExpression)].length, 2);
     assert.equal([...e2eWorkflow.matchAll(runnerExpression)].length, 1);
+    assert.equal([...runnerSmokeWorkflow.matchAll(runnerExpression)].length, 1);
+    assert.match(runnerSmokeWorkflow, /test "\$RUNNER_NAME" = "automation-nuc-courtlistener-mcp"/);
     assert.match(cloudflareReleaseWorkflow, /runs-on: ubuntu-latest/);
     assert.doesNotMatch(cloudflareReleaseWorkflow, /CI_LINUX_RUNNER/);
   });

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -59,6 +59,9 @@ describe('GitHub workflow hardening', () => {
     assert.match(workflow, /hashFiles\('release-state\.json'\) != ''/);
     assert.match(workflow, /probe_directory=release-probes-promoted/);
     assert.match(workflow, /decision=rollback/);
+    assert.match(workflow, /resume_from_run_id:/);
+    assert.match(workflow, /Restore validated release state/);
+    assert.match(workflow, /gh run download/);
     assert.match(
       workflow,
       /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7/,

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -191,6 +191,11 @@ describe('GitHub workflow hardening', () => {
     );
     assert.match(performanceWorkflow, /pnpm run ci:load-profile-suite/);
     assert.match(performanceWorkflow, /check-local-health\.mjs/);
+    assert.match(performanceWorkflow, /find-free-port\.mjs/);
+    assert.match(
+      performanceWorkflow,
+      /LOCAL_WORKERS_PORT="\$\(node scripts\/dev\/find-free-port\.mjs\)"/,
+    );
     assert.match(performanceWorkflow, /github\.event\.inputs\.environment != 'local'/);
     assert.doesNotMatch(performanceWorkflow, /echo ['"]Performance tests available/);
     assert.doesNotMatch(ciWorkflow, /pnpm run test:performance/);

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -191,6 +191,7 @@ describe('GitHub workflow hardening', () => {
     );
     assert.match(performanceWorkflow, /pnpm run ci:load-profile-suite/);
     assert.match(performanceWorkflow, /check-local-health\.mjs/);
+    assert.match(performanceWorkflow, /github\.event\.inputs\.environment != 'local'/);
     assert.doesNotMatch(performanceWorkflow, /echo ['"]Performance tests available/);
     assert.doesNotMatch(ciWorkflow, /pnpm run test:performance/);
   });

--- a/test/unit/test-github-workflows.ts
+++ b/test/unit/test-github-workflows.ts
@@ -69,6 +69,21 @@ describe('GitHub workflow hardening', () => {
     );
   });
 
+  it('routes validation workloads through the optional trusted NUC runner', () => {
+    const ciWorkflow = read('../../.github/workflows/ci.yml');
+    const performanceWorkflow = read('../../.github/workflows/performance.yml');
+    const e2eWorkflow = read('../../.github/workflows/e2e-auth-chat-flow.yml');
+    const cloudflareReleaseWorkflow = read('../../.github/workflows/cloudflare-release.yml');
+    const runnerExpression =
+      /runs-on: \$\{\{ fromJSON\(vars\.CI_LINUX_RUNNER \|\| '"ubuntu-latest"'\) \}\}/g;
+
+    assert.equal([...ciWorkflow.matchAll(runnerExpression)].length, 7);
+    assert.equal([...performanceWorkflow.matchAll(runnerExpression)].length, 2);
+    assert.equal([...e2eWorkflow.matchAll(runnerExpression)].length, 1);
+    assert.match(cloudflareReleaseWorkflow, /runs-on: ubuntu-latest/);
+    assert.doesNotMatch(cloudflareReleaseWorkflow, /CI_LINUX_RUNNER/);
+  });
+
   it('does not eval secret-derived remote endpoint output in CI', () => {
     const workflows = [
       read('../../.github/workflows/ci.yml'),


### PR DESCRIPTION
## What changed
- Route validation, performance, and hosted OAuth jobs through the optional trusted NUC runner.
- Preserve hosted-runner fallback and keep Cloudflare production release authority hosted.
- Add a NUC runner smoke workflow and isolate local Worker ports across repositories.
- Skip the remote health check for explicit local performance runs.

## Why
Use the existing NUC validation capacity without moving production credentials or deployment authority.

## Impact
The repository variable `CI_LINUX_RUNNER` now selects the NUC; unset values fall back to `ubuntu-latest`. Local Worker checks use an allocated loopback port to avoid collisions with other NUC jobs.

## Testing
- Workflow hardening tests: 20/20 passed.
- Performance Monitoring local dispatch passed on `automation-nuc-courtlistener-mcp` in run 33275368657.
- Runner API reports the NUC online with labels `self-hosted`, `Linux`, `X64`, `nuc`, `courtlistener-mcp`.

## Screenshots
Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI runner selection and Cloudflare release resume semantics; misconfigured `CI_LINUX_RUNNER` or wrong resume run could route jobs to the wrong host or deploy with mismatched source SHA.
> 
> **Overview**
> Validation, performance, and hosted OAuth GitHub Actions jobs now use **`vars.CI_LINUX_RUNNER`** (JSON label array) with **`ubuntu-latest`** fallback, while **Cloudflare release** stays on hosted runners. README documents the trusted NUC label set and trust boundary.
> 
> A new **runner smoke** workflow verifies the expected NUC identity. **Performance monitoring** allocates a free loopback port via `find-free-port.mjs`, passes **`LOCAL_WORKERS_PORT`** into `dev:workers`, and skips the remote health job when dispatch targets **local** only.
> 
> **Cloudflare release** adds **`resume_from_run_id`** to restore `release-state.json` from a prior artifact and drive **`CLOUDFLARE_RELEASE_SOURCE_SHA`** through upload/canary/promote/rollback/finalize. **`parseVersionId`** also accepts Wrangler **Current Version ID** output. Hosted auth setup checks send a dedicated **User-Agent** on `/auth/start` probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95e3aa8eb14618c892a0a0a2d446e5dd5a280cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional support for resuming validated Cloudflare releases from a previous workflow run.
  - Added a manually triggered runner smoke test for validating operating system, architecture, and Git availability.
  - Added configurable validation and performance runners, with automatic fallback to standard hosted runners.
  - Added automatic free-port selection for local worker testing.

- **Improvements**
  - Improved release compatibility with additional deployment output formats.
  - Enhanced hosted authentication readiness checks.

- **Documentation**
  - Documented setup and security considerations for optional self-hosted validation runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->