### PR TITLE
chore(config): remove stale transport declarations

### DIFF
--- a/legal-mcp.code-workspace
+++ b/legal-mcp.code-workspace
@@ -85,7 +85,6 @@
     "git.confirmSync": false,
 
     // Testing Configuration
-    "mochaExplorer.files": ["test/**/*.js"],
     "testExplorer.codeLens": true,
     "testExplorer.gutterDecoration": true,
     "testExplorer.onStart": "reset",
@@ -107,7 +106,11 @@
                     "command": { "type": "string" },
                     "args": { "type": "array", "items": { "type": "string" } },
                     "env": { "type": "object" },
-                    "type": { "type": "string", "enum": ["stdio", "sse", "http"] },
+                    "type": { "type": "string", "enum": ["stdio"] },
+                    "transport": {
+                      "type": "string",
+                      "enum": ["streamable-http"],
+                    },
                     "url": { "type": "string" },
                   },
                 },


### PR DESCRIPTION
## What changed
- Remove the obsolete Mocha JavaScript test explorer glob.
- Remove deprecated SSE and HTTP transport declarations from the workspace schema.
- Add the active Streamable HTTP transport field while retaining supported stdio configuration.

## Why
The workspace still advertised removed transport and test paths after the MCP v2 migration, increasing configuration drift and developer confusion.

## Impact
Configuration-only cleanup; no runtime or production deployment changes.

## Testing
- `pnpm exec prettier --check legal-mcp.code-workspace`
- `git diff --check`
- Full `pnpm run ci:local-gate` passed via pre-push hook (89 unit files, 163 SPA auth tests).

## Screenshots
Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor/workspace JSON schema and test-explorer settings only; no application runtime or deployment behavior changes.
> 
> **Overview**
> Updates **VS Code workspace settings only** so editor hints match post–MCP v2 reality.
> 
> Removes the stale **`mochaExplorer.files`** glob for `test/**/*.js`, since that JS Mocha path is no longer how tests are discovered.
> 
> Refines the **`mcp-config.json` / `claude_desktop_config.json` JSON schema**: **`type`** is limited to **`stdio`** (dropping removed **`sse`** and **`http`** values), and a new **`transport`** field documents **`streamable-http`** alongside existing **`command`**, **`args`**, **`env`**, and **`url`** properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd555708f66b4c7c7151f2b21c3c53af06a7e11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->